### PR TITLE
Added Android support for AdvertisementData

### DIFF
--- a/Sources/GATT/AdvertisementData.swift
+++ b/Sources/GATT/AdvertisementData.swift
@@ -32,7 +32,7 @@ public protocol AdvertisementDataProtocol: Equatable {
     var solicitedServiceUUIDs: [BluetoothUUID]? { get }
 }
 
-#if os(macOS) || os(Linux)
+#if os(macOS) || os(Linux) || os(Android)
 
 public struct AdvertisementData: AdvertisementDataProtocol {
     


### PR DESCRIPTION
**Issue**

GATT is not compiling on Android

**What does this PR Do?**

Conditionally compile `AdvertisementData` for Android.

**Where should the reviewer start?**

`AdvertisementData.swift`