### PR TITLE
Always link GATT statically

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     products: [
         .library(
             name: "GATT",
-            type: libraryType,
+            type: .static,
             targets: ["GATT"]
         ),
         .library(

--- a/Package@swift-5.3.swift
+++ b/Package@swift-5.3.swift
@@ -12,7 +12,7 @@ let package = Package(
     products: [
         .library(
             name: "GATT",
-            type: libraryType,
+            type: .static,
             targets: ["GATT"]
         ),
         .library(


### PR DESCRIPTION
**Issue**

Fixes #24.

**What does this PR Do?**

Changes the library type to always link `GATT` statically. `DawinGATT` stays unchanged.

**Where should the reviewer start?**

`Package.swift`