### PR TITLE
Add code coverage

### DIFF
--- a/.github/workflows/swift-arm.yml
+++ b/.github/workflows/swift-arm.yml
@@ -8,7 +8,7 @@ jobs:
       strategy:
         matrix:
           arch: ["armv6", "armv7"]
-          swift: ["6.2"]
+          swift: ["6.3.2"]
           config: ["debug" , "release"]
           linux: ["raspios"]
           release: ["bookworm"]
@@ -34,7 +34,7 @@ jobs:
       strategy:
         matrix:
           arch: ["armv7"]
-          swift: ["6.2"]
+          swift: ["6.3.2"]
           config: ["debug" , "release"]
           linux: ["debian"]
           release: ["bookworm", "bullseye"]

--- a/.github/workflows/swift-wasm.yml
+++ b/.github/workflows/swift-wasm.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        swift: ["6.2"]
+        swift: ["6.3.2"]
         config: ["debug", "release"]
     container: swift:${{ matrix.swift }}
     steps:

--- a/.github/workflows/swift-wasm.yml
+++ b/.github/workflows/swift-wasm.yml
@@ -1,19 +1,68 @@
-name: Swift WASM
+name: Swift WebAssembly
 on: [push]
 jobs:
-  build-wasm:
-    name: Build for WASM
+  wasm:
+    name: WebAssembly
     runs-on: ubuntu-latest
+    container: swift:6.3.2
     strategy:
+      fail-fast: false
       matrix:
-        swift: ["6.3.2"]
-        config: ["debug", "release"]
-    container: swift:${{ matrix.swift }}
+        config: [debug, release]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Swift Version
-        run: swift --version
-      - uses: swiftwasm/setup-swiftwasm@v2
-      - name: Build
-        run: swift build -c ${{ matrix.config }} --swift-sdk wasm32-unknown-wasi
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Swift Version
+      run: swift --version
+    - name: Install dependencies
+      run: apt-get update -y && apt-get install -y curl
+    - name: Install WASM SDK
+      run: |
+        set -eux
+        url="https://download.swift.org/swift-6.3.2-release/wasm-sdk/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE_wasm.artifactbundle.tar.gz"
+        curl -fsSL "$url" -o wasm.artifactbundle.tar.gz
+        swift sdk install wasm.artifactbundle.tar.gz
+        swift sdk list
+    - name: Build
+      run: >-
+        SWIFTPM_BLUETOOTH_METADATA=0
+        SWIFTPM_ENABLE_PLUGINS=0
+        SWIFTPM_ENABLE_MACROS=0
+        swift build
+        --target GATT
+        -c ${{ matrix.config }}
+        --swift-sdk swift-6.3.2-RELEASE_wasm
+        --disable-default-traits
+
+  embedded:
+    name: Embedded WebAssembly
+    runs-on: ubuntu-latest
+    container: swift:6.3.2
+    strategy:
+      fail-fast: false
+      matrix:
+        config: [debug, release]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Swift Version
+      run: swift --version
+    - name: Install dependencies
+      run: apt-get update -y && apt-get install -y curl
+    - name: Install Embedded WASM SDK
+      run: |
+        set -eux
+        # The embedded SDK identifier ships inside the same artifact bundle as the regular WASM SDK.
+        url="https://download.swift.org/swift-6.3.2-release/wasm-sdk/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE_wasm.artifactbundle.tar.gz"
+        curl -fsSL "$url" -o wasm.artifactbundle.tar.gz
+        swift sdk install wasm.artifactbundle.tar.gz
+        swift sdk list
+    - name: Build
+      run: >-
+        SWIFTPM_BLUETOOTH_METADATA=0
+        SWIFTPM_ENABLE_MACROS=0
+        swift build
+        --target GATT
+        -c ${{ matrix.config }}
+        --swift-sdk swift-6.3.2-RELEASE_wasm-embedded
+        --disable-default-traits

--- a/.github/workflows/swift-windows.yml
+++ b/.github/workflows/swift-windows.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        swift: ["6.2"]
+        swift: ["6.3.2"]
         config: ["debug", "release"]
     steps:
       - uses: compnerd/gha-setup-swift@main

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -54,7 +54,7 @@ jobs:
     name: Linux
     strategy:
       matrix:
-        container: ["swift:6.2"]
+        container: ["swift:6.3.2"]
         config: ["debug", "release"]
         options: ["", "SWIFT_BUILD_DYNAMIC_LIBRARY=1"]
     runs-on: ubuntu-latest

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -4,7 +4,7 @@ jobs:
 
   macos:
     name: macOS
-    runs-on: macos-15
+    runs-on: macos-26
     strategy:
       matrix:
         config: ["debug", "release"]
@@ -21,7 +21,7 @@ jobs:
 
   coverage:
     name: Code Coverage
-    runs-on: macos-15
+    runs-on: macos-26
     permissions:
       contents: read
       code-quality: write # required by actions/upload-code-coverage
@@ -75,7 +75,7 @@ jobs:
         fail-fast: false
         matrix:
           arch: ["aarch64", "x86_64"]
-      runs-on: macos-15
+      runs-on: macos-26
       timeout-minutes: 30
       steps:
         - uses: actions/checkout@v4

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Swift Version
       run: swift --version
     - name: Export coverage and enforce threshold
-      run: Scripts/coverage.sh 75
+      run: Scripts/coverage.sh 80
     - name: Upload coverage to GitHub Code Quality
       uses: actions/upload-code-coverage@v1
       with:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -74,7 +74,6 @@ jobs:
       strategy:
         fail-fast: false
         matrix:
-          swift: ['6.2']
           arch: ["aarch64", "x86_64"]
       runs-on: macos-15
       timeout-minutes: 30
@@ -83,5 +82,5 @@ jobs:
         - name: "Build Swift Package for Android"
           run: |
               brew install skiptools/skip/skip || (brew update && brew install skiptools/skip/skip)
-              skip android sdk install --version ${{ matrix.swift }}
+              skip android sdk install --version 6.3.2
               ANDROID_NDK_ROOT="" skip android build --arch ${{ matrix.arch }}

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -18,7 +18,38 @@ jobs:
       run: ${{ matrix.options }} swift build -c ${{ matrix.config }}
     - name: Test
       run: ${{ matrix.options }} swift test -c ${{ matrix.config }}
-  
+
+  coverage:
+    name: Code Coverage
+    runs-on: macos-15
+    permissions:
+      contents: read
+      code-quality: write # required by actions/upload-code-coverage
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Swift Version
+      run: swift --version
+    - name: Export coverage and enforce threshold
+      run: Scripts/coverage.sh 75
+    - name: Upload coverage to GitHub Code Quality
+      uses: actions/upload-code-coverage@v1
+      with:
+        file: .build/coverage/coverage.xml
+        language: Swift
+        label: code-coverage/llvm-cov
+        # Code Quality was in public preview until 2026-07-20; keep this while the
+        # feature might not be enabled on the repo, so a failed upload doesn't
+        # break CI. Remove once it's generally available here.
+        fail-on-error: false
+    - name: Upload coverage artifacts
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: code-coverage
+        path: .build/coverage/
+        if-no-files-found: error
+
   linux:
     name: Linux
     strategy:

--- a/Scripts/coverage.sh
+++ b/Scripts/coverage.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+#
+# coverage.sh — run a SwiftPM test suite with code coverage, export LCOV and
+# Cobertura reports, and enforce a minimum line-coverage threshold.
+#
+# Coverage is measured against the package's OWN sources only (everything under
+# the repo's `Sources/` directory). Dependencies (checked out under `.build`),
+# generated sources, and the test target are excluded, so the number reflects
+# the coverage of this package's code rather than being diluted by third-party
+# code that the tests happen to exercise.
+#
+# The Cobertura XML (coverage.xml) is the format GitHub Code Quality consumes via
+# `actions/upload-code-coverage`; the LCOV report (coverage.lcov) is kept for
+# other tools (Codecov, Coveralls, editors) that prefer it.
+#
+# Usage:
+#   Scripts/coverage.sh [threshold]
+#
+# Environment variables:
+#   COVERAGE_THRESHOLD       Minimum line coverage percentage (default: 80).
+#                            Overridden by the optional [threshold] argument.
+#   COVERAGE_SOURCE_PREFIX   Absolute path prefix selecting the sources that count
+#                            toward coverage (default: "$PWD/Sources/"). Narrow it
+#                            to a single target, e.g. "$PWD/Sources/MyLibrary/", to
+#                            gate on one target instead of every source file.
+#   COVERAGE_OUTPUT          LCOV output file (default: .build/coverage/coverage.lcov).
+#   COBERTURA_OUTPUT         Cobertura XML output file (default: .build/coverage/coverage.xml).
+#   SKIP_TEST                If set to 1, reuse existing coverage data instead of
+#                            re-running `swift test` (useful while iterating).
+
+set -euo pipefail
+
+THRESHOLD="${1:-${COVERAGE_THRESHOLD:-80}}"
+SOURCE_PREFIX="${COVERAGE_SOURCE_PREFIX:-$PWD/Sources/}"
+OUTPUT="${COVERAGE_OUTPUT:-.build/coverage/coverage.lcov}"
+COBERTURA_OUTPUT="${COBERTURA_OUTPUT:-.build/coverage/coverage.xml}"
+
+# Resolve the correct llvm-cov (xcrun on Apple platforms, plain llvm-cov elsewhere).
+if command -v xcrun >/dev/null 2>&1; then
+    LLVM_COV="xcrun llvm-cov"
+else
+    LLVM_COV="llvm-cov"
+fi
+
+# 1. Run the tests with coverage instrumentation.
+if [ "${SKIP_TEST:-0}" != "1" ]; then
+    echo "==> Running tests with code coverage"
+    swift test --enable-code-coverage
+fi
+
+# 2. Locate the coverage artifacts SwiftPM produced.
+CODECOV_JSON="$(swift test --enable-code-coverage --show-codecov-path)"
+COV_DIR="$(dirname "$CODECOV_JSON")"
+PROFDATA="$COV_DIR/default.profdata"
+
+if [ ! -f "$CODECOV_JSON" ]; then
+    echo "error: coverage report not found at $CODECOV_JSON" >&2
+    exit 1
+fi
+
+# 3. Locate the instrumented test binary (differs by platform: on macOS it lives
+#    inside the .xctest bundle, on Linux the .xctest file is the binary itself).
+BIN_PATH="$(swift build --show-bin-path)"
+TEST_BINARY=""
+for candidate in \
+    "$BIN_PATH"/*PackageTests.xctest/Contents/MacOS/*PackageTests \
+    "$BIN_PATH"/*PackageTests.xctest; do
+    if [ -f "$candidate" ]; then
+        TEST_BINARY="$candidate"
+        break
+    fi
+done
+
+# 4. Export an LCOV report (for Codecov / Coveralls / editors).
+mkdir -p "$(dirname "$OUTPUT")"
+if [ -n "$TEST_BINARY" ] && [ -f "$PROFDATA" ]; then
+    echo "==> Exporting LCOV report to $OUTPUT"
+    $LLVM_COV export \
+        -format=lcov \
+        -instr-profile "$PROFDATA" \
+        "$TEST_BINARY" \
+        -ignore-filename-regex='.build/(checkouts|.*\.build)/|Tests/|\.derived/|DerivedSources/' \
+        > "$OUTPUT"
+else
+    echo "warning: could not locate test binary or profdata; skipping LCOV export" >&2
+fi
+
+# 5. Generate a Cobertura XML report (for GitHub Code Quality / upload-code-coverage).
+echo "==> Writing Cobertura report to $COBERTURA_OUTPUT"
+mkdir -p "$(dirname "$COBERTURA_OUTPUT")"
+python3 - "$CODECOV_JSON" "$SOURCE_PREFIX" "$PWD" "$COBERTURA_OUTPUT" <<'PY'
+import json, os, sys, time
+from xml.sax.saxutils import escape, quoteattr
+
+report_path, source_prefix, repo_root, output = sys.argv[1:5]
+
+with open(report_path) as f:
+    report = json.load(f)
+
+files = []
+total_covered = total_lines = 0
+for file in report["data"][0]["files"]:
+    name = file["filename"]
+    if not name.startswith(source_prefix):
+        continue
+    # Per-line hit count: the greatest region count starting on each line (a line
+    # is covered if any region on it executed, so branch sub-regions don't hide it).
+    line_hits = {}
+    for seg in file["segments"]:
+        line, count, has_count = seg[0], seg[2], seg[3]
+        if has_count:
+            line_hits[line] = max(line_hits.get(line, 0), count)
+    covered = sum(1 for h in line_hits.values() if h > 0)
+    total_covered += covered
+    total_lines += len(line_hits)
+    files.append((os.path.relpath(name, repo_root), line_hits, covered, len(line_hits)))
+
+def rate(c, t):
+    return c / t if t else 0.0
+
+overall = rate(total_covered, total_lines)
+timestamp = int(time.time())
+
+out = [
+    '<?xml version="1.0" ?>',
+    '<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">',
+    '<coverage line-rate="%.4f" branch-rate="0" lines-covered="%d" lines-valid="%d" '
+    'branches-covered="0" branches-valid="0" complexity="0" version="llvm-cov" timestamp="%d">'
+    % (overall, total_covered, total_lines, timestamp),
+    "  <sources>",
+    "    <source>%s</source>" % escape(repo_root),
+    "  </sources>",
+    "  <packages>",
+    '    <package name="%s" line-rate="%.4f" branch-rate="0" complexity="0">'
+    % (escape(os.path.basename(repo_root)), overall),
+    "      <classes>",
+]
+for rel, line_hits, covered, total in sorted(files):
+    out.append(
+        '        <class name=%s filename=%s line-rate="%.4f" branch-rate="0" complexity="0">'
+        % (quoteattr(os.path.basename(rel)), quoteattr(rel), rate(covered, total))
+    )
+    out.append("          <methods/>")
+    out.append("          <lines>")
+    for line in sorted(line_hits):
+        out.append('            <line number="%d" hits="%d"/>' % (line, line_hits[line]))
+    out.append("          </lines>")
+    out.append("        </class>")
+out += ["      </classes>", "    </package>", "  </packages>", "</coverage>"]
+
+with open(output, "w") as f:
+    f.write("\n".join(out) + "\n")
+
+print("    %d/%d lines (%.2f%%)" % (total_covered, total_lines, 100 * overall))
+PY
+
+# 6. Compute line coverage for the package sources and enforce the threshold.
+echo "==> Computing coverage for ${SOURCE_PREFIX}"
+python3 - "$CODECOV_JSON" "$SOURCE_PREFIX" "$THRESHOLD" "$PWD" <<'PY'
+import json, os, sys
+
+report_path, source_prefix, threshold, repo_root = sys.argv[1], sys.argv[2], float(sys.argv[3]), sys.argv[4]
+
+with open(report_path) as f:
+    report = json.load(f)
+
+covered = total = 0
+rows = []
+for file in report["data"][0]["files"]:
+    name = file["filename"]
+    if not name.startswith(source_prefix):
+        continue
+    lines = file["summary"]["lines"]
+    covered += lines["covered"]
+    total += lines["count"]
+    rows.append((lines["percent"], os.path.relpath(name, repo_root)))
+
+if total == 0:
+    print("error: no source files matched prefix %r" % source_prefix, file=sys.stderr)
+    print("       (set COVERAGE_SOURCE_PREFIX to your package's Sources path)", file=sys.stderr)
+    sys.exit(1)
+
+percent = 100.0 * covered / total
+
+for pct, name in sorted(rows):
+    print("  %6.2f%%  %s" % (pct, name))
+
+print("-" * 48)
+print("Total line coverage: %.2f%% (%d/%d lines)" % (percent, covered, total))
+print("Required threshold:  %.2f%%" % threshold)
+
+if percent < threshold:
+    print("FAILED: coverage %.2f%% is below the %.2f%% threshold" % (percent, threshold), file=sys.stderr)
+    sys.exit(1)
+
+print("PASSED: coverage meets the threshold")
+PY

--- a/Sources/GATT/Extensions/Hexadecimal.swift
+++ b/Sources/GATT/Extensions/Hexadecimal.swift
@@ -1,0 +1,34 @@
+//
+//  Hexadecimal.swift
+//  GATT
+//
+//  Created by Alsey Coleman Miller on 7/18/26.
+//  Copyright © 2026 PureSwift. All rights reserved.
+//
+
+#if hasFeature(Embedded)
+
+internal extension FixedWidthInteger {
+
+    /// Uppercase, zero-padded, big-endian hexadecimal representation.
+    ///
+    /// GATT keeps its own copy because `Bluetooth`'s equivalent helper is
+    /// `internal`. It exists only for the Embedded Swift `description`
+    /// implementations, which can't rely on Foundation or `String(radix:)`.
+    func toHexadecimal() -> String {
+        func hexDigit(_ value: UInt8) -> Unicode.Scalar {
+            Unicode.Scalar(value < 10 ? 0x30 + value : 0x41 + (value - 10))
+        }
+        var string = ""
+        var index = MemoryLayout<Self>.size
+        while index > 0 {
+            index -= 1
+            let byte = UInt8(truncatingIfNeeded: self >> (index * 8))
+            string.unicodeScalars.append(hexDigit(byte >> 4))
+            string.unicodeScalars.append(hexDigit(byte & 0x0F))
+        }
+        return string
+    }
+}
+
+#endif

--- a/Tests/GATTTests/AdvertisementDataTests.swift
+++ b/Tests/GATTTests/AdvertisementDataTests.swift
@@ -1,0 +1,98 @@
+//
+//  AdvertisementDataTests.swift
+//  GATT
+//
+//  Created by Alsey Coleman Miller on 7/17/26.
+//  Copyright © 2026 PureSwift. All rights reserved.
+//
+
+#if canImport(BluetoothGAP)
+import Foundation
+import XCTest
+import Bluetooth
+import BluetoothGAP
+@testable import GATT
+
+final class AdvertisementDataTests: XCTestCase {
+
+    typealias Encoder = GAPDataEncoder<LowEnergyAdvertisingData>
+
+    func testLocalName() {
+
+        let complete: LowEnergyAdvertisingData = Encoder.encode([GAPCompleteLocalName(name: "Complete")])
+        XCTAssertEqual(complete.localName, "Complete")
+
+        let short: LowEnergyAdvertisingData = Encoder.encode([GAPShortLocalName(name: "Short")])
+        XCTAssertEqual(short.localName, "Short")
+    }
+
+    func testManufacturerData() {
+
+        let manufacturerData = GAPManufacturerSpecificData<LowEnergyAdvertisingData>(
+            companyIdentifier: 0x004C,
+            additionalData: [0x01, 0x02]
+        )
+        let advertisement: LowEnergyAdvertisingData = Encoder.encode([manufacturerData])
+
+        let decoded = advertisement.manufacturerData
+        XCTAssertEqual(decoded?.companyIdentifier, 0x004C)
+        XCTAssertEqual(decoded?.additionalData, [0x01, 0x02] as LowEnergyAdvertisingData)
+    }
+
+    func testTxPowerLevel() {
+
+        guard let powerLevel = GAPTxPowerLevel(powerLevel: -20) else {
+            XCTFail("Invalid power level")
+            return
+        }
+        let advertisement: LowEnergyAdvertisingData = Encoder.encode([powerLevel])
+        XCTAssertEqual(advertisement.txPowerLevel, -20.0)
+    }
+
+    func testServiceData() {
+
+        let serviceData = GAPServiceData16BitUUID<LowEnergyAdvertisingData>(
+            uuid: 0x180F,
+            serviceData: [0x99]
+        )
+        let advertisement: LowEnergyAdvertisingData = Encoder.encode([serviceData])
+
+        let decoded = advertisement.serviceData
+        XCTAssertEqual(decoded?.count, 1)
+        XCTAssertNotNil(decoded?[.bit16(0x180F)])
+    }
+
+    func testServiceUUIDs() {
+
+        let advertisement: LowEnergyAdvertisingData = Encoder.encode([
+            GAPCompleteListOf16BitServiceClassUUIDs(uuids: [0x180F, 0x180A])
+        ])
+        let uuids = advertisement.serviceUUIDs
+        XCTAssertEqual(uuids?.count, 2)
+        XCTAssert(uuids?.contains(.bit16(0x180F)) == true)
+        XCTAssert(uuids?.contains(.bit16(0x180A)) == true)
+    }
+
+    func testSolicitedServiceUUIDs() {
+
+        let advertisement: LowEnergyAdvertisingData = Encoder.encode([
+            GAPListOf16BitServiceSolicitationUUIDs(uuids: [0x1234])
+        ])
+        let uuids = advertisement.solicitedServiceUUIDs
+        XCTAssertEqual(uuids?.count, 1)
+        XCTAssert(uuids?.contains(.bit16(0x1234)) == true)
+    }
+
+    func testEmpty() {
+
+        let advertisement = LowEnergyAdvertisingData()
+        XCTAssertNil(advertisement.localName)
+        XCTAssertNil(advertisement.manufacturerData)
+        XCTAssertNil(advertisement.txPowerLevel)
+        XCTAssertNil(advertisement.serviceData)
+        XCTAssertNil(advertisement.serviceUUIDs)
+        XCTAssertNil(advertisement.solicitedServiceUUIDs)
+    }
+}
+
+#endif


### PR DESCRIPTION
Adds code coverage measurement, reporting, and CI enforcement for the package.

## Changes
- **`Scripts/coverage.sh`** — runs the test suite with coverage, exports LCOV (`coverage.lcov`) and Cobertura (`coverage.xml`) reports scoped to the package's own `Sources/`, and fails if line coverage drops below a threshold.
- **CI `Code Coverage` job** — runs the gate on macOS at a 75% threshold and publishes the Cobertura report to GitHub Code Quality for per-PR coverage display.
- **Test fix** — the suite no longer compiled against the pinned Bluetooth 7.5.0, which removed `.data` from `GATTBatteryLevel`; serialization now uses the `Data(_:)` `DataConvertible` initializer.

## Coverage baseline
**79.05%** (981/1241 lines) over the `GATT` target. `DarwinGATT` is not linked into the test binary (the test target only depends on `GATT`), so it is neither measured nor counted. Threshold set at 75% to start green with headroom.