### PR TITLE
Gate GATT server on a package trait, require Swift 6.2

### DIFF
--- a/.github/workflows/swift-arm.yml
+++ b/.github/workflows/swift-arm.yml
@@ -8,7 +8,7 @@ jobs:
       strategy:
         matrix:
           arch: ["armv6", "armv7"]
-          swift: ["6.1.2"]
+          swift: ["6.2"]
           config: ["debug" , "release"]
           linux: ["raspios"]
           release: ["bookworm"]
@@ -34,7 +34,7 @@ jobs:
       strategy:
         matrix:
           arch: ["armv7"]
-          swift: ["6.1.2"]
+          swift: ["6.2"]
           config: ["debug" , "release"]
           linux: ["debian"]
           release: ["bookworm", "bullseye"]

--- a/.github/workflows/swift-wasm.yml
+++ b/.github/workflows/swift-wasm.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        swift: ["6.0.3"]
+        swift: ["6.2"]
         config: ["debug", "release"]
     container: swift:${{ matrix.swift }}
     steps:

--- a/.github/workflows/swift-windows.yml
+++ b/.github/workflows/swift-windows.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        swift: ["6.1.2"]
+        swift: ["6.2"]
         config: ["debug", "release"]
     steps:
       - uses: compnerd/gha-setup-swift@main

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -23,7 +23,7 @@ jobs:
     name: Linux
     strategy:
       matrix:
-        container: ["swift:6.0.3", "swift:6.1.2"]
+        container: ["swift:6.2"]
         config: ["debug", "release"]
         options: ["", "SWIFT_BUILD_DYNAMIC_LIBRARY=1"]
     runs-on: ubuntu-latest
@@ -43,7 +43,7 @@ jobs:
       strategy:
         fail-fast: false
         matrix:
-          swift: ['6.1', 'nightly-6.2']
+          swift: ['6.2']
           arch: ["aarch64", "x86_64"]
       runs-on: macos-15
       timeout-minutes: 30

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.2
 import PackageDescription
 import class Foundation.ProcessInfo
 
@@ -26,10 +26,17 @@ var package = Package(
             targets: ["DarwinGATT"]
         )
     ],
+    traits: [
+        .default(enabledTraits: ["GATTServer"]),
+        .trait(
+            name: "GATTServer",
+            description: "Enable the pure Swift GATT server (peripheral) and central implementation and its dependencies (BluetoothGATT, BluetoothHCI)."
+        )
+    ],
     dependencies: [
         .package(
             url: "https://github.com/PureSwift/Bluetooth.git",
-            from: "7.2.0"
+            from: "7.5.0"
         )
     ],
     targets: [
@@ -43,7 +50,7 @@ var package = Package(
                 .product(
                     name: "BluetoothGATT",
                     package: "Bluetooth",
-                    condition: .when(platforms: [.macOS, .iOS, .linux])
+                    condition: .when(traits: ["GATTServer"])
                 ),
                 .product(
                     name: "BluetoothGAP",
@@ -53,7 +60,7 @@ var package = Package(
                 .product(
                     name: "BluetoothHCI",
                     package: "Bluetooth",
-                    condition: .when(platforms: [.macOS, .iOS, .linux])
+                    condition: .when(traits: ["GATTServer"])
                 )
             ]
         ),
@@ -80,7 +87,7 @@ var package = Package(
                 .product(
                     name: "BluetoothGATT",
                     package: "Bluetooth",
-                    condition: .when(platforms: [.macOS, .iOS, .linux])
+                    condition: .when(traits: ["GATTServer"])
                 ),
                 .product(
                     name: "BluetoothGAP",
@@ -90,7 +97,7 @@ var package = Package(
                 .product(
                     name: "BluetoothHCI",
                     package: "Bluetooth",
-                    condition: .when(platforms: [.macOS, .iOS, .linux])
+                    condition: .when(traits: ["GATTServer"])
                 )
             ],
             swiftSettings: [.swiftLanguageMode(.v5)]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,24 @@ GATT is available as a Swift Package Manager package. To use it, add the followi
 
 and to your target, add `GATT` to your dependencies. You can then `import GATT` to get access to GATT functionality.
 
+### Package Traits
+
+GATT requires **Swift 6.2** and uses [package traits](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0450-swiftpm-package-traits.md) to gate the pure Swift GATT stack:
+
+| Trait | Default | Description |
+| ---- | ---- | ---- |
+| `GATTServer` | Enabled | Enables the pure Swift GATT peripheral (`GATTPeripheral`) and central (`GATTCentral`) implementation and its dependencies (`BluetoothGATT`, `BluetoothHCI`). |
+
+The `GATTServer` trait is enabled by default on every platform, so the pure Swift GATT stack is no longer tied to a specific platform. Disable it (for example, when you only need `DarwinGATT`/CoreBluetooth, or for size-constrained builds) by opting out of default traits for the dependency:
+
+```swift
+.package(
+    url: "https://github.com/PureSwift/GATT.git",
+    branch: "master",
+    traits: []
+),
+```
+
 ## Platforms
 
 | Platform | Roles | Backend | Library |
@@ -108,7 +126,7 @@ License
 
 **GATT** is released under the MIT license. See LICENSE for details.
 
-[swift-badge]: https://img.shields.io/badge/swift-6.0-F05138.svg "Swift 6.0"
+[swift-badge]: https://img.shields.io/badge/swift-6.2-F05138.svg "Swift 6.2"
 [swift-url]: https://swift.org
 [platform-badge]: https://img.shields.io/badge/platform-macOS%20%7C%20iOS%20%7C%20watchOS%20%7C%20tvOS%20%7C%20Linux%20%7C%20Android-lightgrey.svg
 [platform-url]: https://swift.org

--- a/Tests/GATTTests/GATTTests.swift
+++ b/Tests/GATTTests/GATTTests.swift
@@ -183,7 +183,7 @@ final class GATTTests: XCTestCase {
         let characteristics = [
             GATTAttribute<Data>.Characteristic(
                 uuid: type(of: batteryLevel).uuid,
-                value: batteryLevel.data,
+                value: Data(batteryLevel),
                 permissions: [.read],
                 properties: [.read, .notify],
                 descriptors: [.init(GATTClientCharacteristicConfiguration(), permissions: [.read, .write])])
@@ -237,7 +237,7 @@ final class GATTTests: XCTestCase {
         let characteristics = [
             GATTAttribute<Data>.Characteristic(
                 uuid: type(of: batteryLevel).uuid,
-                value: batteryLevel.data,
+                value: Data(batteryLevel),
                 permissions: [.read, .write],
                 properties: [.read, .write],
                 descriptors: []
@@ -267,13 +267,13 @@ final class GATTTests: XCTestCase {
                 XCTAssertEqual(currentValue, characteristics[0].value)
                 peripheral.willWrite = {
                     XCTAssertEqual($0.uuid, BluetoothUUID.Characteristic.batteryLevel)
-                    XCTAssertEqual($0.value, batteryLevel.data)
-                    XCTAssertEqual($0.newValue, newValue.data)
+                    XCTAssertEqual($0.value, Data(batteryLevel))
+                    XCTAssertEqual($0.newValue, Data(newValue))
                     return nil
                 }
                 peripheral.didWrite = {
                     XCTAssertEqual($0.uuid, BluetoothUUID.Characteristic.batteryLevel)
-                    XCTAssertEqual($0.value, newValue.data)
+                    XCTAssertEqual($0.value, Data(newValue))
                 }
             },
             client: { (central, peripheral) in
@@ -297,12 +297,12 @@ final class GATTTests: XCTestCase {
                     else { XCTFail(); return }
                 XCTAssertEqual(characteristicValue, batteryLevel)
                 // write value
-                try await central.writeValue(newValue.data, for: foundCharacteristic, withResponse: true)
+                try await central.writeValue(Data(newValue), for: foundCharacteristic, withResponse: true)
                 // validate
                 let currentValue = await peripheralDatabaseValue()
-                XCTAssertEqual(currentValue, newValue.data)
+                XCTAssertEqual(currentValue, Data(newValue))
                 XCTAssertNotEqual(currentValue, characteristics[0].value)
-                XCTAssertNotEqual(currentValue, characteristicValue.data)
+                XCTAssertNotEqual(currentValue, Data(characteristicValue))
             }
         )
     }
@@ -315,7 +315,7 @@ final class GATTTests: XCTestCase {
         let characteristics = [
             GATTAttribute<Data>.Characteristic(
                 uuid: type(of: batteryLevel).uuid,
-                value: batteryLevel.data,
+                value: Data(batteryLevel),
                 permissions: [.read],
                 properties: [.read, .notify],
                 descriptors: [.init(GATTClientCharacteristicConfiguration(), permissions: [.read, .write])]
@@ -339,7 +339,7 @@ final class GATTTests: XCTestCase {
                 let characteristicValueHandle = characteristicValueHandles[0]
                 Task {
                     try await Task.sleep(nanoseconds: 1_000_000_000)
-                    peripheral.write(newValue.data, forCharacteristic: characteristicValueHandle)
+                    peripheral.write(Data(newValue), forCharacteristic: characteristicValueHandle)
                 }
             },
             client: { (central, peripheral) in
@@ -380,7 +380,7 @@ final class GATTTests: XCTestCase {
         let characteristics = [
             GATTAttribute<Data>.Characteristic(
                 uuid: type(of: batteryLevel).uuid,
-                value: batteryLevel.data,
+                value: Data(batteryLevel),
                 permissions: [.read],
                 properties: [.read, .indicate],
                 descriptors: [.init(GATTClientCharacteristicConfiguration(), permissions: [.read, .write])]
@@ -404,7 +404,7 @@ final class GATTTests: XCTestCase {
                 let characteristicValueHandle = characteristicValueHandles[0]
                 Task {
                     try await Task.sleep(nanoseconds: 1_000_000_000)
-                    peripheral.write(newValue.data, forCharacteristic: characteristicValueHandle)
+                    peripheral.write(Data(newValue), forCharacteristic: characteristicValueHandle)
                 }
             },
             client: { (central, peripheral) in


### PR DESCRIPTION
## Summary

Replaces platform-based gating of the pure Swift GATT server/central stack with a SwiftPM **package trait**, so the functionality is no longer tied to specific platforms. Also raises the minimum toolchain to **Swift 6.2** and updates dependencies.

Closes #41.

## Changes

- **Package.swift**
  - `swift-tools-version` `6.0` → `6.2` (required for package traits).
  - New `GATTServer` trait (enabled by default) that gates the `BluetoothGATT` and `BluetoothHCI` dependencies for the `GATT` target and test target — via `condition: .when(traits: ["GATTServer"])` instead of `condition: .when(platforms: [.macOS, .iOS, .linux])`.
  - `Bluetooth` dependency bumped `7.2.0` → `7.5.0`.
- **Tests** — Updated for the Bluetooth 7.5 `DataConvertible` API (`value.data` → `Data(value)`).
- **CI** — All workflows (`swift`, `swift-wasm`, `swift-windows`, `swift-arm`, Android) bumped to Swift `6.2`.
- **README** — Documents the `GATTServer` trait with an opt-out example; Swift badge → 6.2.

## Notes

- The trait is enabled by default, so existing consumers see no behavior change; the pure Swift GATT stack is now available on any platform and can be opted out of (`traits: []`).
- Works because sources already gate on `#if canImport(BluetoothGATT)`, which now follows the trait-controlled linkage. Shared types (`AttributePermissions`, `CharacteristicProperties`, `MaximumTransmissionUnit`) keep their `#else` fallbacks, so `DarwinGATT` builds even with the trait disabled.
- The `swift-arm` job pulls a prebuilt `swift-armv7` SDK by tag — the `6.2` release must exist for that job to pass.

## Verification

- `swift build` (default traits) — Build complete
- `swift build --disable-default-traits` — Build complete
- `swift test` — 7 tests, 0 failures