### PR TITLE
Update BluetoothGATT trait and support Embedded Swift in GATTPeripheral

### DIFF
--- a/.github/workflows/swift-arm.yml
+++ b/.github/workflows/swift-arm.yml
@@ -26,7 +26,7 @@ jobs:
         - name: Swift Version
           run: swift --version
         - name: Build
-          run: SWIFT_BUILD_DYNAMIC_LIBRARY=1 swift build -c ${{ matrix.config }} --destination /opt/swift-${{ matrix.swift }}-RELEASE-${{ matrix.linux }}-${{ matrix.release }}-${{ matrix.arch }}/${{ matrix.linux }}-${{ matrix.release }}.json
+          run: SWIFT_BUILD_DYNAMIC_LIBRARY=1 swift build -c ${{ matrix.config }} --traits BluetoothGATT --destination /opt/swift-${{ matrix.swift }}-RELEASE-${{ matrix.linux }}-${{ matrix.release }}-${{ matrix.arch }}/${{ matrix.linux }}-${{ matrix.release }}.json
 
     linux-arm-debian-build:
       name: Linux (Debian)
@@ -52,7 +52,7 @@ jobs:
         - name: Swift Version
           run: swift --version
         - name: Build
-          run: SWIFT_BUILD_DYNAMIC_LIBRARY=1 swift build -c ${{ matrix.config }} --destination /opt/swift-${{ matrix.swift }}-RELEASE-${{ matrix.linux }}-${{ matrix.release }}-${{ matrix.arch }}/${{ matrix.linux }}-${{ matrix.release }}.json
+          run: SWIFT_BUILD_DYNAMIC_LIBRARY=1 swift build -c ${{ matrix.config }} --traits BluetoothGATT --destination /opt/swift-${{ matrix.swift }}-RELEASE-${{ matrix.linux }}-${{ matrix.release }}-${{ matrix.arch }}/${{ matrix.linux }}-${{ matrix.release }}.json
         - name: Upload artifacts
           uses: actions/upload-artifact@v4
           with:

--- a/.github/workflows/swift-wasm.yml
+++ b/.github/workflows/swift-wasm.yml
@@ -26,6 +26,7 @@ jobs:
     - name: Build
       run: >-
         SWIFTPM_BLUETOOTH_METADATA=0
+        SWIFTPM_ENABLE_PLUGINS=0
         SWIFTPM_ENABLE_MACROS=0
         swift build
         --target GATT

--- a/.github/workflows/swift-wasm.yml
+++ b/.github/workflows/swift-wasm.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         config: [debug, release]
-        traits: ["", "--disable-default-traits"]
+        traits: ["--traits BluetoothGATT", ""]
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         config: [debug, release]
-        traits: ["", "--disable-default-traits"]
+        traits: ["--traits BluetoothGATT", ""]
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/swift-wasm.yml
+++ b/.github/workflows/swift-wasm.yml
@@ -26,7 +26,6 @@ jobs:
     - name: Build
       run: >-
         SWIFTPM_BLUETOOTH_METADATA=0
-        SWIFTPM_ENABLE_PLUGINS=0
         SWIFTPM_ENABLE_MACROS=0
         swift build
         --target GATT

--- a/.github/workflows/swift-wasm.yml
+++ b/.github/workflows/swift-wasm.yml
@@ -9,6 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         config: [debug, release]
+        traits: ["", "--disable-default-traits"]
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -26,13 +27,12 @@ jobs:
     - name: Build
       run: >-
         SWIFTPM_BLUETOOTH_METADATA=0
-        SWIFTPM_ENABLE_PLUGINS=0
         SWIFTPM_ENABLE_MACROS=0
         swift build
         --target GATT
         -c ${{ matrix.config }}
         --swift-sdk swift-6.3.2-RELEASE_wasm
-        --disable-default-traits
+        ${{ matrix.traits }}
 
   embedded:
     name: Embedded WebAssembly
@@ -42,6 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         config: [debug, release]
+        traits: ["", "--disable-default-traits"]
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -65,4 +66,4 @@ jobs:
         --target GATT
         -c ${{ matrix.config }}
         --swift-sdk swift-6.3.2-RELEASE_wasm-embedded
-        --disable-default-traits
+        ${{ matrix.traits }}

--- a/.github/workflows/swift-windows.yml
+++ b/.github/workflows/swift-windows.yml
@@ -8,6 +8,7 @@ jobs:
       matrix:
         swift: ["6.3.2"]
         config: ["debug", "release"]
+        traits: ["--traits BluetoothGATT", ""]
     steps:
       - uses: compnerd/gha-setup-swift@main
         with:
@@ -18,4 +19,4 @@ jobs:
       - name: Swift Version
         run: swift --version
       - name: Build
-        run: swift build -c ${{ matrix.config }}
+        run: swift build -c ${{ matrix.config }} ${{ matrix.traits }}

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -9,15 +9,16 @@ jobs:
       matrix:
         config: ["debug", "release"]
         options: ["", "SWIFT_BUILD_DYNAMIC_LIBRARY=1"]
+        traits: ["--traits BluetoothGATT", ""]
     steps:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Swift Version
       run: swift --version
     - name: Build
-      run: ${{ matrix.options }} swift build -c ${{ matrix.config }}
+      run: ${{ matrix.options }} swift build -c ${{ matrix.config }} ${{ matrix.traits }}
     - name: Test
-      run: ${{ matrix.options }} swift test -c ${{ matrix.config }}
+      run: ${{ matrix.options }} swift test -c ${{ matrix.config }} ${{ matrix.traits }}
 
   coverage:
     name: Code Coverage
@@ -32,6 +33,9 @@ jobs:
       run: swift --version
     - name: Export coverage and enforce threshold
       run: Scripts/coverage.sh 80
+      env:
+        # Measure coverage of the pure Swift GATT stack (opt-in trait).
+        SWIFT_BUILD_FLAGS: --traits BluetoothGATT
     - name: Upload coverage to GitHub Code Quality
       uses: actions/upload-code-coverage@v1
       with:
@@ -57,6 +61,7 @@ jobs:
         container: ["swift:6.3.2"]
         config: ["debug", "release"]
         options: ["", "SWIFT_BUILD_DYNAMIC_LIBRARY=1"]
+        traits: ["--traits BluetoothGATT", ""]
     runs-on: ubuntu-latest
     container: ${{ matrix.container }}-jammy
     steps:
@@ -65,9 +70,9 @@ jobs:
     - name: Swift Version
       run: swift --version
     - name: Build
-      run: ${{ matrix.options }} swift build -c ${{ matrix.config }}
+      run: ${{ matrix.options }} swift build -c ${{ matrix.config }} ${{ matrix.traits }}
     - name: Test
-      run: ${{ matrix.options }} swift test -c ${{ matrix.config }}
+      run: ${{ matrix.options }} swift test -c ${{ matrix.config }} ${{ matrix.traits }}
 
   android:
       name: Android

--- a/Package.swift
+++ b/Package.swift
@@ -27,10 +27,10 @@ var package = Package(
         )
     ],
     traits: [
-        .default(enabledTraits: ["GATTServer"]),
+        .default(enabledTraits: ["BluetoothGATT"]),
         .trait(
-            name: "GATTServer",
-            description: "Enable the pure Swift GATT server (peripheral) implementation (GATTPeripheral)."
+            name: "BluetoothGATT",
+            description: "Import the BluetoothGATT module, enabling the pure Swift GATT server (GATTPeripheral) and using BluetoothGATT types instead of the lightweight shims for platforms like iOS and Android."
         )
     ],
     dependencies: [
@@ -49,7 +49,8 @@ var package = Package(
                 ),
                 .product(
                     name: "BluetoothGATT",
-                    package: "Bluetooth"
+                    package: "Bluetooth",
+                    condition: .when(traits: ["BluetoothGATT"])
                 ),
                 .product(
                     name: "BluetoothGAP",
@@ -58,7 +59,8 @@ var package = Package(
                 ),
                 .product(
                     name: "BluetoothHCI",
-                    package: "Bluetooth"
+                    package: "Bluetooth",
+                    condition: .when(traits: ["BluetoothGATT"])
                 )
             ]
         ),
@@ -69,7 +71,7 @@ var package = Package(
                 .product(
                     name: "BluetoothGATT",
                     package: "Bluetooth",
-                    condition: .when(platforms: [.macOS, .iOS])
+                    condition: .when(platforms: [.macOS, .iOS], traits: ["BluetoothGATT"])
                 )
             ],
             swiftSettings: [.swiftLanguageMode(.v5)]
@@ -84,7 +86,8 @@ var package = Package(
                 ),
                 .product(
                     name: "BluetoothGATT",
-                    package: "Bluetooth"
+                    package: "Bluetooth",
+                    condition: .when(traits: ["BluetoothGATT"])
                 ),
                 .product(
                     name: "BluetoothGAP",
@@ -93,7 +96,8 @@ var package = Package(
                 ),
                 .product(
                     name: "BluetoothHCI",
-                    package: "Bluetooth"
+                    package: "Bluetooth",
+                    condition: .when(traits: ["BluetoothGATT"])
                 )
             ],
             swiftSettings: [.swiftLanguageMode(.v5)]

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ var package = Package(
         .default(enabledTraits: ["GATTServer"]),
         .trait(
             name: "GATTServer",
-            description: "Enable the pure Swift GATT server (peripheral) and central implementation and its dependencies (BluetoothGATT, BluetoothHCI)."
+            description: "Enable the pure Swift GATT server (peripheral) implementation (GATTPeripheral)."
         )
     ],
     dependencies: [
@@ -49,8 +49,7 @@ var package = Package(
                 ),
                 .product(
                     name: "BluetoothGATT",
-                    package: "Bluetooth",
-                    condition: .when(traits: ["GATTServer"])
+                    package: "Bluetooth"
                 ),
                 .product(
                     name: "BluetoothGAP",
@@ -59,8 +58,7 @@ var package = Package(
                 ),
                 .product(
                     name: "BluetoothHCI",
-                    package: "Bluetooth",
-                    condition: .when(traits: ["GATTServer"])
+                    package: "Bluetooth"
                 )
             ]
         ),
@@ -86,8 +84,7 @@ var package = Package(
                 ),
                 .product(
                     name: "BluetoothGATT",
-                    package: "Bluetooth",
-                    condition: .when(traits: ["GATTServer"])
+                    package: "Bluetooth"
                 ),
                 .product(
                     name: "BluetoothGAP",
@@ -96,8 +93,7 @@ var package = Package(
                 ),
                 .product(
                     name: "BluetoothHCI",
-                    package: "Bluetooth",
-                    condition: .when(traits: ["GATTServer"])
+                    package: "Bluetooth"
                 )
             ],
             swiftSettings: [.swiftLanguageMode(.v5)]

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,6 @@ var package = Package(
         )
     ],
     traits: [
-        .default(enabledTraits: ["BluetoothGATT"]),
         .trait(
             name: "BluetoothGATT",
             description: "Import the BluetoothGATT module, enabling the pure Swift GATT server (GATTPeripheral) and using BluetoothGATT types instead of the lightweight shims for platforms like iOS and Android."

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ GATT requires **Swift 6.2** and uses [package traits](https://github.com/swiftla
 
 | Trait | Default | Description |
 | ---- | ---- | ---- |
-| `GATTServer` | Enabled | Enables the pure Swift GATT server (peripheral) implementation (`GATTPeripheral`). |
+| `BluetoothGATT` | Enabled | Imports the `BluetoothGATT` module, enabling the pure Swift GATT server (`GATTPeripheral`, `PeripheralManager`) and making the central use the `BluetoothGATT` types (`GATTCharacteristicProperties`, `ATTAttributePermissions`, `ATTMaximumTransmissionUnit`) instead of the lightweight shims. |
 
-The GATT client (central) implementation (`GATTCentral`) is always available and is not affected by this trait. The `GATTServer` trait is enabled by default on every platform, so the pure Swift GATT server is no longer tied to a specific platform. Disable it (for example, when you only need the central role, `DarwinGATT`/CoreBluetooth, or for size-constrained builds) by opting out of default traits for the dependency:
+The `BluetoothGATT` trait is enabled by default on every platform, so the pure Swift GATT stack is no longer tied to a specific platform. Disable it for central-only clients built on a platform Bluetooth stack (for example CoreBluetooth on iOS or the Android Bluetooth API), where the lightweight shim types are used instead and the GATT server role is unavailable:
 
 ```swift
 .package(

--- a/README.md
+++ b/README.md
@@ -23,15 +23,17 @@ GATT requires **Swift 6.2** and uses [package traits](https://github.com/swiftla
 
 | Trait | Default | Description |
 | ---- | ---- | ---- |
-| `BluetoothGATT` | Enabled | Imports the `BluetoothGATT` module, enabling the pure Swift GATT server (`GATTPeripheral`, `PeripheralManager`) and making the central use the `BluetoothGATT` types (`GATTCharacteristicProperties`, `ATTAttributePermissions`, `ATTMaximumTransmissionUnit`) instead of the lightweight shims. |
+| `BluetoothGATT` | Disabled | Imports the `BluetoothGATT` module, enabling the pure Swift GATT server (`GATTPeripheral`, `PeripheralManager`) and making the central use the `BluetoothGATT` types (`GATTCharacteristicProperties`, `ATTAttributePermissions`, `ATTMaximumTransmissionUnit`) instead of the lightweight shims. |
 
-The `BluetoothGATT` trait is enabled by default on every platform, so the pure Swift GATT stack is no longer tied to a specific platform. On platforms without threading (Embedded Swift targets like Pi Pico W, ESP32 or nRF52840 running BTStack, NimBLE or Zephyr), `GATTPeripheral` is driven by calling its non-blocking `run()` method from the platform's run loop instead of background threads. Disable the trait for central-only clients built on a platform Bluetooth stack (for example CoreBluetooth on iOS or the Android Bluetooth API), where the lightweight shim types are used instead and the GATT server role is unavailable:
+By default the `BluetoothGATT` trait is disabled, so GATT builds against the lightweight shim types. This suits central-only clients built on a platform Bluetooth stack (for example CoreBluetooth on iOS or the Android Bluetooth API), where the platform provides the GATT server and the shims keep the dependency footprint small.
+
+Enable the trait when you need a GATT server (peripheral). This applies to both the pure Swift `GATTPeripheral` and the CoreBluetooth-backed `DarwinPeripheral`; the shim build provides the central role only. On platforms without threading (Embedded Swift targets like Pi Pico W, ESP32 or nRF52840 running BTStack, NimBLE or Zephyr), `GATTPeripheral` is driven by calling its non-blocking `run()` method from the platform's run loop instead of background threads.
 
 ```swift
 .package(
     url: "https://github.com/PureSwift/GATT.git",
     branch: "master",
-    traits: []
+    traits: ["BluetoothGATT"]
 ),
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ GATT requires **Swift 6.2** and uses [package traits](https://github.com/swiftla
 | ---- | ---- | ---- |
 | `BluetoothGATT` | Enabled | Imports the `BluetoothGATT` module, enabling the pure Swift GATT server (`GATTPeripheral`, `PeripheralManager`) and making the central use the `BluetoothGATT` types (`GATTCharacteristicProperties`, `ATTAttributePermissions`, `ATTMaximumTransmissionUnit`) instead of the lightweight shims. |
 
-The `BluetoothGATT` trait is enabled by default on every platform, so the pure Swift GATT stack is no longer tied to a specific platform. Disable it for central-only clients built on a platform Bluetooth stack (for example CoreBluetooth on iOS or the Android Bluetooth API), where the lightweight shim types are used instead and the GATT server role is unavailable:
+The `BluetoothGATT` trait is enabled by default on every platform, so the pure Swift GATT stack is no longer tied to a specific platform. On platforms without threading (Embedded Swift targets like Pi Pico W, ESP32 or nRF52840 running BTStack, NimBLE or Zephyr), `GATTPeripheral` is driven by calling its non-blocking `run()` method from the platform's run loop instead of background threads. Disable the trait for central-only clients built on a platform Bluetooth stack (for example CoreBluetooth on iOS or the Android Bluetooth API), where the lightweight shim types are used instead and the GATT server role is unavailable:
 
 ```swift
 .package(

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ GATT requires **Swift 6.2** and uses [package traits](https://github.com/swiftla
 
 | Trait | Default | Description |
 | ---- | ---- | ---- |
-| `GATTServer` | Enabled | Enables the pure Swift GATT peripheral (`GATTPeripheral`) and central (`GATTCentral`) implementation and its dependencies (`BluetoothGATT`, `BluetoothHCI`). |
+| `GATTServer` | Enabled | Enables the pure Swift GATT server (peripheral) implementation (`GATTPeripheral`). |
 
-The `GATTServer` trait is enabled by default on every platform, so the pure Swift GATT stack is no longer tied to a specific platform. Disable it (for example, when you only need `DarwinGATT`/CoreBluetooth, or for size-constrained builds) by opting out of default traits for the dependency:
+The GATT client (central) implementation (`GATTCentral`) is always available and is not affected by this trait. The `GATTServer` trait is enabled by default on every platform, so the pure Swift GATT server is no longer tied to a specific platform. Disable it (for example, when you only need the central role, `DarwinGATT`/CoreBluetooth, or for size-constrained builds) by opting out of default traits for the dependency:
 
 ```swift
 .package(

--- a/Scripts/coverage.sh
+++ b/Scripts/coverage.sh
@@ -35,6 +35,11 @@ SOURCE_PREFIX="${COVERAGE_SOURCE_PREFIX:-$PWD/Sources/}"
 OUTPUT="${COVERAGE_OUTPUT:-.build/coverage/coverage.lcov}"
 COBERTURA_OUTPUT="${COBERTURA_OUTPUT:-.build/coverage/coverage.xml}"
 
+# Extra flags forwarded to every `swift build`/`swift test` invocation (e.g.
+# "--traits BluetoothGATT" to measure coverage of the pure Swift GATT stack).
+# shellcheck disable=SC2206
+SWIFT_FLAGS=(${SWIFT_BUILD_FLAGS:-})
+
 # Resolve the correct llvm-cov (xcrun on Apple platforms, plain llvm-cov elsewhere).
 if command -v xcrun >/dev/null 2>&1; then
     LLVM_COV="xcrun llvm-cov"
@@ -45,11 +50,11 @@ fi
 # 1. Run the tests with coverage instrumentation.
 if [ "${SKIP_TEST:-0}" != "1" ]; then
     echo "==> Running tests with code coverage"
-    swift test --enable-code-coverage
+    swift test --enable-code-coverage ${SWIFT_FLAGS[@]+"${SWIFT_FLAGS[@]}"}
 fi
 
 # 2. Locate the coverage artifacts SwiftPM produced.
-CODECOV_JSON="$(swift test --enable-code-coverage --show-codecov-path)"
+CODECOV_JSON="$(swift test --enable-code-coverage --show-codecov-path ${SWIFT_FLAGS[@]+"${SWIFT_FLAGS[@]}"})"
 COV_DIR="$(dirname "$CODECOV_JSON")"
 PROFDATA="$COV_DIR/default.profdata"
 
@@ -60,7 +65,7 @@ fi
 
 # 3. Locate the instrumented test binary (differs by platform: on macOS it lives
 #    inside the .xctest bundle, on Linux the .xctest file is the binary itself).
-BIN_PATH="$(swift build --show-bin-path)"
+BIN_PATH="$(swift build --show-bin-path ${SWIFT_FLAGS[@]+"${SWIFT_FLAGS[@]}"})"
 TEST_BINARY=""
 for candidate in \
     "$BIN_PATH"/*PackageTests.xctest/Contents/MacOS/*PackageTests \

--- a/Sources/DarwinGATT/DarwinAttributes.swift
+++ b/Sources/DarwinGATT/DarwinAttributes.swift
@@ -7,7 +7,7 @@
 //
 
 // watchOS and tvOS only support Central mode
-#if (os(macOS) || os(iOS)) && canImport(BluetoothGATT)
+#if (os(macOS) || os(iOS)) && BluetoothGATT
 import Foundation
 import Bluetooth
 import BluetoothGATT

--- a/Sources/DarwinGATT/DarwinDescriptor.swift
+++ b/Sources/DarwinGATT/DarwinDescriptor.swift
@@ -124,7 +124,7 @@ extension DarwinDescriptor {
     }
 }
 
-#if (os(macOS) || os(iOS)) && canImport(BluetoothGATT)
+#if (os(macOS) || os(iOS)) && BluetoothGATT
 internal extension CBMutableDescriptor {
     
     /// Only the characteristic user description descriptor and the characteristic format descriptor

--- a/Sources/DarwinGATT/DarwinPeripheral.swift
+++ b/Sources/DarwinGATT/DarwinPeripheral.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 PureSwift. All rights reserved.
 //
 
-#if (os(macOS) || os(iOS)) && canImport(BluetoothGATT)
+#if (os(macOS) || os(iOS)) && BluetoothGATT
 import Foundation
 import Dispatch
 import Bluetooth

--- a/Sources/GATT/AttributePermission.swift
+++ b/Sources/GATT/AttributePermission.swift
@@ -6,7 +6,7 @@
 //
 
 @_exported import Bluetooth
-#if canImport(BluetoothGATT)
+#if BluetoothGATT
 @_exported import BluetoothGATT
 public typealias AttributePermissions = BluetoothGATT.ATTAttributePermissions
 #else

--- a/Sources/GATT/CharacteristicProperty.swift
+++ b/Sources/GATT/CharacteristicProperty.swift
@@ -6,7 +6,7 @@
 //
 
 @_exported import Bluetooth
-#if canImport(BluetoothGATT)
+#if BluetoothGATT
 @_exported import BluetoothGATT
 public typealias CharacteristicProperties = BluetoothGATT.GATTCharacteristicProperties
 #else

--- a/Sources/GATT/GATTCentral.swift
+++ b/Sources/GATT/GATTCentral.swift
@@ -8,7 +8,7 @@
 #if canImport(Foundation)
 import Foundation
 #endif
-#if canImport(BluetoothGATT) && canImport(BluetoothHCI) && !hasFeature(Embedded)
+#if canImport(BluetoothGATT) && canImport(BluetoothHCI)
 @_exported import Bluetooth
 @_exported import BluetoothGATT
 @_exported import BluetoothHCI

--- a/Sources/GATT/GATTCentral.swift
+++ b/Sources/GATT/GATTCentral.swift
@@ -10,7 +10,7 @@ import Foundation
 #endif
 // GATTClient is an actor and relies on Swift Concurrency,
 // which Embedded Swift does not yet support.
-#if canImport(BluetoothGATT) && canImport(BluetoothHCI) && !hasFeature(Embedded)
+#if BluetoothGATT && !hasFeature(Embedded)
 @_exported import Bluetooth
 @_exported import BluetoothGATT
 @_exported import BluetoothHCI

--- a/Sources/GATT/GATTCentral.swift
+++ b/Sources/GATT/GATTCentral.swift
@@ -8,7 +8,7 @@
 #if canImport(Foundation)
 import Foundation
 #endif
-#if canImport(BluetoothGATT) && canImport(BluetoothHCI)
+#if canImport(BluetoothGATT) && canImport(BluetoothHCI) && !hasFeature(Embedded)
 @_exported import Bluetooth
 @_exported import BluetoothGATT
 @_exported import BluetoothHCI

--- a/Sources/GATT/GATTCentral.swift
+++ b/Sources/GATT/GATTCentral.swift
@@ -8,7 +8,9 @@
 #if canImport(Foundation)
 import Foundation
 #endif
-#if canImport(BluetoothGATT) && canImport(BluetoothHCI)
+// GATTClient is an actor and relies on Swift Concurrency,
+// which Embedded Swift does not yet support.
+#if canImport(BluetoothGATT) && canImport(BluetoothHCI) && !hasFeature(Embedded)
 @_exported import Bluetooth
 @_exported import BluetoothGATT
 @_exported import BluetoothHCI

--- a/Sources/GATT/GATTClientConnection.swift
+++ b/Sources/GATT/GATTClientConnection.swift
@@ -5,7 +5,7 @@
 //  Created by Alsey Coleman Miller on 7/18/18.
 //
 
-#if canImport(BluetoothGATT) && !hasFeature(Embedded)
+#if canImport(BluetoothGATT)
 import Bluetooth
 import BluetoothGATT
 

--- a/Sources/GATT/GATTClientConnection.swift
+++ b/Sources/GATT/GATTClientConnection.swift
@@ -7,7 +7,7 @@
 
 // GATTClient is an actor and relies on Swift Concurrency,
 // which Embedded Swift does not yet support.
-#if canImport(BluetoothGATT) && !hasFeature(Embedded)
+#if BluetoothGATT && !hasFeature(Embedded)
 import Bluetooth
 import BluetoothGATT
 

--- a/Sources/GATT/GATTClientConnection.swift
+++ b/Sources/GATT/GATTClientConnection.swift
@@ -5,7 +5,9 @@
 //  Created by Alsey Coleman Miller on 7/18/18.
 //
 
-#if canImport(BluetoothGATT)
+// GATTClient is an actor and relies on Swift Concurrency,
+// which Embedded Swift does not yet support.
+#if canImport(BluetoothGATT) && !hasFeature(Embedded)
 import Bluetooth
 import BluetoothGATT
 

--- a/Sources/GATT/GATTClientConnection.swift
+++ b/Sources/GATT/GATTClientConnection.swift
@@ -5,7 +5,7 @@
 //  Created by Alsey Coleman Miller on 7/18/18.
 //
 
-#if canImport(BluetoothGATT)
+#if canImport(BluetoothGATT) && !hasFeature(Embedded)
 import Bluetooth
 import BluetoothGATT
 

--- a/Sources/GATT/GATTPeripheral.swift
+++ b/Sources/GATT/GATTPeripheral.swift
@@ -8,7 +8,7 @@
 #if canImport(Foundation)
 import Foundation
 #endif
-#if canImport(BluetoothGATT) && canImport(BluetoothHCI)
+#if GATTServer && canImport(BluetoothGATT) && canImport(BluetoothHCI) && !hasFeature(Embedded) && !os(WASI)
 @_exported import Bluetooth
 @_exported import BluetoothGATT
 @_exported import BluetoothHCI

--- a/Sources/GATT/GATTPeripheral.swift
+++ b/Sources/GATT/GATTPeripheral.swift
@@ -8,7 +8,7 @@
 #if canImport(Foundation)
 import Foundation
 #endif
-#if canImport(BluetoothGATT) && canImport(BluetoothHCI)
+#if BluetoothGATT
 @_exported import Bluetooth
 @_exported import BluetoothGATT
 @_exported import BluetoothHCI

--- a/Sources/GATT/GATTPeripheral.swift
+++ b/Sources/GATT/GATTPeripheral.swift
@@ -14,7 +14,13 @@ import Foundation
 @_exported import BluetoothHCI
 
 /// GATT Peripheral Manager
-public final class GATTPeripheral <HostController: BluetoothHostControllerInterface, Socket: L2CAPServer>: PeripheralManager, @unchecked Sendable where Socket.Error == Socket.Connection.Error {
+///
+/// The host controller is only used for configuring advertising via the async
+/// `start()` and `start(options:)` APIs, which require a `BluetoothHostControllerInterface`.
+/// Platform Bluetooth stacks that manage advertising themselves (e.g. BTStack, NimBLE)
+/// can use any host controller type and start the server with `start(address:isRandom:)`,
+/// driving I/O by polling `run()` from the platform's run loop.
+public final class GATTPeripheral <HostController, Socket: L2CAPServer>: PeripheralManager, @unchecked Sendable where Socket.Error == Socket.Connection.Error {
     
     /// Central Peer
     public typealias Central = GATT.Central
@@ -93,7 +99,7 @@ public final class GATTPeripheral <HostController: BluetoothHostControllerInterf
         }
     }
         
-    private let lock = NSLock()
+    private let lock = Lock()
     
     // MARK: - Initialization
     
@@ -114,19 +120,11 @@ public final class GATTPeripheral <HostController: BluetoothHostControllerInterf
     
     // MARK: - Methods
     
-    public func start() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else {
-            fatalError("Requires Swift concurrency runtime")
-        }
-        // ignore errors
-        Task {
-            do { try await start(options: .init()) }
-            catch {
-                assertionFailure("Unable to start GATT server: \(error)")
-            }
-        }
+    public func start() throws(Error) {
+        // Advertising must be configured by the platform's Bluetooth stack.
+        try start(address: .zero, isRandom: false)
     }
-    
+
     public func start(address: BluetoothAddress, isRandom: Bool) throws(Error) {
         // create server socket
         let socket: Socket
@@ -140,56 +138,50 @@ public final class GATTPeripheral <HostController: BluetoothHostControllerInterf
         catch {
             throw .connection(.socket(error))
         }
-        
+        self.storage.socket = socket
+        #if canImport(Foundation) && !os(WASI)
         // start listening for connections
         let thread = Thread { [weak self] in
             self?.log?("Started GATT Server")
             // listen for
             while let self = self, self.storage.isAdvertising, let socket = self.storage.socket {
-                self.accept(socket)
+                self.acceptThread(socket)
             }
         }
-        self.storage.socket = socket
         self.storage.thread = thread
         thread.start()
+        #else
+        // I/O is driven by calling `run()` from the platform's run loop.
+        self.log?("Started GATT Server")
+        #endif
     }
-    
-    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-    public func start(options: GATTPeripheralAdvertisingOptions) async throws {
-        assert(isAdvertising == false)
-        
-        // use public or random address
-        let address: BluetoothAddress
-        if let randomAddress = options.randomAddress {
-            address = randomAddress
-            try await hostController.lowEnergySetRandomAddress(randomAddress)
-        } else {
-            address = try await hostController.readDeviceAddress()
+
+    /// Process a pending connection and read and write from connected centrals, without blocking.
+    ///
+    /// Call this repeatedly from the platform's run loop on platforms without threading
+    /// (e.g. Embedded Swift with BTStack or NimBLE); on other platforms I/O is
+    /// serviced automatically by background threads.
+    public func run() {
+        // accept a pending connection
+        if let socket = storage.socket, socket.status.accept {
+            do {
+                try accept(socket)
+            }
+            catch {
+                log?("Error accepting new connection: \(error)")
+            }
         }
-        
-        // set advertising data and scan response
-        if options.advertisingData != nil || options.scanResponse != nil {
-            do { try await hostController.enableLowEnergyAdvertising(false) }
-            catch HCIError.commandDisallowed { /* ignore */ }
+        // read and write for each connection
+        for (central, connection) in storage.connections {
+            do {
+                try connection.run()
+            }
+            catch {
+                didDisconnect(central, log: log)
+            }
         }
-        if let advertisingData = options.advertisingData {
-            try await hostController.setLowEnergyAdvertisingData(advertisingData)
-        }
-        if let scanResponse = options.scanResponse {
-            try await hostController.setLowEnergyScanResponse(scanResponse)
-        }
-        
-        // enable advertising
-        do { try await hostController.enableLowEnergyAdvertising() }
-        catch HCIError.commandDisallowed { /* ignore */ }
-        
-        // start listening thread
-        try start(
-            address: address,
-            isRandom: options.randomAddress != nil
-        )
     }
-    
+
     public func stop() {
         storage.stop()
         log?("Stopped GATT Server")
@@ -240,6 +232,72 @@ public final class GATTPeripheral <HostController: BluetoothHostControllerInterf
     }
 }
 
+#if !hasFeature(Embedded)
+public extension GATTPeripheral where HostController: BluetoothHostControllerInterface {
+
+    /// Configure advertising with the host controller and start the GATT server.
+    func start() throws(Error) {
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else {
+            fatalError("Requires Swift concurrency runtime")
+        }
+        // ignore errors
+        Task {
+            do { try await start(options: .init()) }
+            catch {
+                assertionFailure("Unable to start GATT server: \(error)")
+            }
+        }
+    }
+
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    func start(options: GATTPeripheralAdvertisingOptions) async throws {
+        assert(isAdvertising == false)
+
+        // use public or random address
+        let address: BluetoothAddress
+        if let randomAddress = options.randomAddress {
+            address = randomAddress
+            try await hostController.lowEnergySetRandomAddress(randomAddress)
+        } else {
+            address = try await hostController.readDeviceAddress()
+        }
+
+        // set advertising data and scan response
+        if options.advertisingData != nil || options.scanResponse != nil {
+            do { try await hostController.enableLowEnergyAdvertising(false) }
+            catch HCIError.commandDisallowed { /* ignore */ }
+        }
+        if let advertisingData = options.advertisingData {
+            try await hostController.setLowEnergyAdvertisingData(advertisingData)
+        }
+        if let scanResponse = options.scanResponse {
+            try await hostController.setLowEnergyScanResponse(scanResponse)
+        }
+
+        // enable advertising
+        do { try await hostController.enableLowEnergyAdvertising() }
+        catch HCIError.commandDisallowed { /* ignore */ }
+
+        // re-enable advertising when a central disconnects
+        let hostController = self.hostController
+        let log = self.log
+        self.storage.reAdvertise = {
+            Task {
+                do { try await hostController.enableLowEnergyAdvertising() }
+                catch HCIError.commandDisallowed { /* ignore */ }
+                catch { log?("Could not enable advertising. \(error)") }
+            }
+        }
+
+        // start listening thread
+        try start(
+            address: address,
+            isRandom: options.randomAddress != nil
+        )
+    }
+}
+#endif
+
 internal extension GATTPeripheral {
     
     func log(_ central: Central, _ message: String) {
@@ -263,6 +321,19 @@ internal extension GATTPeripheral {
     
     func callback(for central: Central) -> GATTServer<Socket.Connection>.Callback {
         var callback = GATTServer<Socket.Connection>.Callback()
+        #if hasFeature(Embedded)
+        // Weak references are unavailable in Embedded Swift;
+        // the peripheral is expected to outlive its connections.
+        callback.willRead = {
+            self.willRead(central: central, uuid: $0, handle: $1, value: $2, offset: $3)
+        }
+        callback.willWrite = {
+            self.willWrite(central: central, uuid: $0, handle: $1, value: $2, newValue: $3)
+        }
+        callback.didWrite = { (uuid, handle, value) in
+            self.didWrite(central: central, uuid: uuid, handle: handle, value: value)
+        }
+        #else
         callback.willRead = { [weak self] in
             self?.willRead(central: central, uuid: $0, handle: $1, value: $2, offset: $3)
         }
@@ -272,6 +343,7 @@ internal extension GATTPeripheral {
         callback.didWrite = { [weak self] (uuid, handle, value) in
             self?.didWrite(central: central, uuid: uuid, handle: handle, value: value)
         }
+        #endif
         return callback
     }
     
@@ -324,7 +396,33 @@ internal extension GATTPeripheral {
         didWrite?(confirmation)
     }
     
+    /// Accept a pending connection, without blocking.
+    @discardableResult
     func accept(
+        _ socket: Socket
+    ) throws(Socket.Error) -> GATTServerConnection<Socket.Connection> {
+        let log = self.log
+        let newSocket = try socket.accept()
+        log?("[\(newSocket.address)]: New connection")
+        let central = Central(id: socket.address)
+        let connection = GATTServerConnection(
+            central: central,
+            socket: newSocket,
+            maximumTransmissionUnit: options.maximumTransmissionUnit,
+            maximumPreparedWrites: options.maximumPreparedWrites,
+            database: storage.database,
+            callback: callback(for: central),
+            log: {
+                log?("[\(central)]: " + $0)
+            }
+        )
+        storage.newConnection(connection)
+        return connection
+    }
+
+    #if canImport(Foundation) && !os(WASI)
+    /// Wait for a pending connection and service its I/O on a background thread.
+    func acceptThread(
         _ socket: Socket
     ) {
         let log = self.log
@@ -339,21 +437,8 @@ internal extension GATTPeripheral {
                     return
                 }
             }
-            let newSocket = try socket.accept()
-            log?("[\(newSocket.address)]: New connection")
-            let central = Central(id: socket.address)
-            let connection = GATTServerConnection(
-                central: central,
-                socket: newSocket,
-                maximumTransmissionUnit: options.maximumTransmissionUnit,
-                maximumPreparedWrites: options.maximumPreparedWrites,
-                database: storage.database,
-                callback: callback(for: central),
-                log: {
-                    log?("[\(central)]: " + $0)
-                }
-            )
-            storage.newConnection(connection)
+            let connection = try accept(socket)
+            let central = connection.central
             Thread.detachNewThread { [weak connection, weak self] in
                 do {
                     while let connection, self != nil {
@@ -373,20 +458,14 @@ internal extension GATTPeripheral {
             Thread.sleep(forTimeInterval: 1.0)
         }
     }
-    
+    #endif
+
     func didDisconnect(
         _ central: Central,
         log: (@Sendable (String) -> ())?
     ) {
         // try advertising again
-        let hostController = self.hostController
-        if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
-            Task {
-                do { try await hostController.enableLowEnergyAdvertising() }
-                catch HCIError.commandDisallowed { /* ignore */ }
-                catch { log?("Could not enable advertising. \(error)") }
-            }
-        }
+        storage.reAdvertise?()
         // remove connection cache
         storage.removeConnection(central)
         // log
@@ -460,22 +539,29 @@ internal extension GATTPeripheral {
         var log: (@Sendable (String) -> ())?
         
         var socket: Socket?
-        
+
+        /// Invoked after a central disconnects, to re-enable advertising.
+        var reAdvertise: (@Sendable () -> ())?
+
+        #if canImport(Foundation) && !os(WASI)
         var thread: Thread?
-        
+        #endif
+
         var connections = [Central: GATTServerConnection<Socket.Connection>](minimumCapacity: 2)
-                
+
         fileprivate init() { }
-        
+
         var isAdvertising: Bool {
             socket != nil
         }
-        
+
         mutating func stop() {
             assert(socket != nil)
             socket = nil
+            #if canImport(Foundation) && !os(WASI)
             thread?.cancel()
             thread = nil
+            #endif
         }
         
         mutating func add(service: GATTAttribute<Data>.Service) -> (UInt16, [UInt16]) {

--- a/Sources/GATT/GATTPeripheral.swift
+++ b/Sources/GATT/GATTPeripheral.swift
@@ -8,7 +8,7 @@
 #if canImport(Foundation)
 import Foundation
 #endif
-#if GATTServer && canImport(BluetoothGATT) && canImport(BluetoothHCI) && !hasFeature(Embedded) && !os(WASI)
+#if canImport(BluetoothGATT) && canImport(BluetoothHCI) && !hasFeature(Embedded) && !os(WASI)
 @_exported import Bluetooth
 @_exported import BluetoothGATT
 @_exported import BluetoothHCI

--- a/Sources/GATT/GATTPeripheral.swift
+++ b/Sources/GATT/GATTPeripheral.swift
@@ -8,7 +8,7 @@
 #if canImport(Foundation)
 import Foundation
 #endif
-#if canImport(BluetoothGATT) && canImport(BluetoothHCI) && !hasFeature(Embedded) && !os(WASI)
+#if canImport(BluetoothGATT) && canImport(BluetoothHCI)
 @_exported import Bluetooth
 @_exported import BluetoothGATT
 @_exported import BluetoothHCI

--- a/Sources/GATT/GATTServerConnection.swift
+++ b/Sources/GATT/GATTServerConnection.swift
@@ -8,7 +8,7 @@
 #if canImport(Foundation)
 import Foundation
 #endif
-#if canImport(BluetoothGATT)
+#if GATTServer && canImport(BluetoothGATT) && !hasFeature(Embedded) && !os(WASI)
 import Bluetooth
 import BluetoothGATT
 

--- a/Sources/GATT/GATTServerConnection.swift
+++ b/Sources/GATT/GATTServerConnection.swift
@@ -8,7 +8,7 @@
 #if canImport(Foundation)
 import Foundation
 #endif
-#if canImport(BluetoothGATT)
+#if BluetoothGATT
 import Bluetooth
 import BluetoothGATT
 

--- a/Sources/GATT/GATTServerConnection.swift
+++ b/Sources/GATT/GATTServerConnection.swift
@@ -8,7 +8,7 @@
 #if canImport(Foundation)
 import Foundation
 #endif
-#if GATTServer && canImport(BluetoothGATT) && !hasFeature(Embedded) && !os(WASI)
+#if canImport(BluetoothGATT) && !hasFeature(Embedded) && !os(WASI)
 import Bluetooth
 import BluetoothGATT
 

--- a/Sources/GATT/GATTServerConnection.swift
+++ b/Sources/GATT/GATTServerConnection.swift
@@ -8,7 +8,7 @@
 #if canImport(Foundation)
 import Foundation
 #endif
-#if canImport(BluetoothGATT) && !hasFeature(Embedded) && !os(WASI)
+#if canImport(BluetoothGATT)
 import Bluetooth
 import BluetoothGATT
 

--- a/Sources/GATT/GATTServerConnection.swift
+++ b/Sources/GATT/GATTServerConnection.swift
@@ -29,7 +29,7 @@ internal final class GATTServerConnection <Socket: L2CAPConnection>: @unchecked 
         Int(server.maximumTransmissionUnit.rawValue) - 3
     }
     
-    private let lock = NSLock()
+    private let lock = Lock()
     
     // MARK: - Initialization
     

--- a/Sources/GATT/L2CAP.swift
+++ b/Sources/GATT/L2CAP.swift
@@ -5,7 +5,7 @@
 //  Created by Alsey Coleman Miller on 4/18/22.
 //
 
-#if canImport(BluetoothHCI)
+#if BluetoothGATT
 import Bluetooth
 import BluetoothHCI
 

--- a/Sources/GATT/Lock.swift
+++ b/Sources/GATT/Lock.swift
@@ -1,0 +1,35 @@
+//
+//  Lock.swift
+//  GATT
+//
+//  Created by Alsey Coleman Miller on 7/18/26.
+//
+
+#if canImport(Foundation)
+import Foundation
+#endif
+
+/// Internal mutual exclusion primitive.
+///
+/// No-op on platforms without threading (e.g. Embedded Swift),
+/// where the stack is driven by polling from the platform's run loop.
+internal struct Lock: @unchecked Sendable {
+
+    #if canImport(Foundation)
+    private let nsLock = NSLock()
+    #endif
+
+    init() { }
+
+    func lock() {
+        #if canImport(Foundation)
+        nsLock.lock()
+        #endif
+    }
+
+    func unlock() {
+        #if canImport(Foundation)
+        nsLock.unlock()
+        #endif
+    }
+}

--- a/Sources/GATT/MaximumTransmissionUnit.swift
+++ b/Sources/GATT/MaximumTransmissionUnit.swift
@@ -6,7 +6,7 @@
 //
 
 @_exported import Bluetooth
-#if canImport(BluetoothGATT)
+#if BluetoothGATT
 @_exported import BluetoothGATT
 public typealias MaximumTransmissionUnit = ATTMaximumTransmissionUnit
 #else

--- a/Sources/GATT/PeripheralProtocol.swift
+++ b/Sources/GATT/PeripheralProtocol.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 PureSwift. All rights reserved.
 //
 
-#if canImport(BluetoothGATT)
+#if BluetoothGATT
 @_exported import Bluetooth
 @_exported import BluetoothGATT
 

--- a/Tests/GATTTests/GATTTests.swift
+++ b/Tests/GATTTests/GATTTests.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-#if GATTServer && canImport(BluetoothGATT)
+#if canImport(BluetoothGATT)
 import Foundation
 import XCTest
 import Bluetooth

--- a/Tests/GATTTests/GATTTests.swift
+++ b/Tests/GATTTests/GATTTests.swift
@@ -545,7 +545,7 @@ extension GATTTests {
         peripheral.log = { print("Peripheral:", $0) }
         try await server(peripheral)
         
-        peripheral.start()
+        try peripheral.start()
         defer { peripheral.stop() }
         
         // central

--- a/Tests/GATTTests/GATTTests.swift
+++ b/Tests/GATTTests/GATTTests.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-#if canImport(BluetoothGATT)
+#if BluetoothGATT
 import Foundation
 import XCTest
 import Bluetooth

--- a/Tests/GATTTests/GATTTests.swift
+++ b/Tests/GATTTests/GATTTests.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-#if canImport(BluetoothGATT)
+#if GATTServer && canImport(BluetoothGATT)
 import Foundation
 import XCTest
 import Bluetooth

--- a/Tests/GATTTests/TestHostController.swift
+++ b/Tests/GATTTests/TestHostController.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
-#if canImport(BluetoothHCI)
+#if BluetoothGATT
 import Foundation
 import Bluetooth
 import BluetoothHCI


### PR DESCRIPTION
## Overview

Reworks the SwiftPM trait introduced in #42 and makes the pure Swift GATT server build for Embedded Swift targets so it can be driven by platform stacks like [BTStack](https://github.com/MillerTechnologyPeru/BTStack), [NimBLE](https://github.com/MillerTechnologyPeru/NimBLE), and [Zephyr](https://github.com/MillerTechnologyPeru/Zephyr-Swift).

## Trait changes

- Renamed the `GATTServer` trait to `BluetoothGATT`: the trait now gates the import of the `BluetoothGATT` module (and `BluetoothHCI`) rather than individual source files.
- With the trait enabled (default), the pure Swift GATT server (`GATTPeripheral`, `PeripheralManager`) is available and the central uses the `BluetoothGATT` types (`GATTCharacteristicProperties`, `ATTAttributePermissions`, `ATTMaximumTransmissionUnit`) via typealiases.
- With the trait disabled, the lightweight shim types are used instead, for central-only clients built on a platform Bluetooth stack such as CoreBluetooth on iOS or the Android Bluetooth API. `DarwinGATT`'s `BluetoothGATT` dependency is gated on the trait as well, so `DarwinPeripheral` is only built when the GATT module provides `PeripheralManager`.

## Embedded Swift support

`GATTPeripheral` and `GATTServerConnection` now compile under Embedded Swift:

- Added a non-blocking `run()` method that accepts pending connections and services I/O for connected centrals, so the peripheral can be driven by polling from the platform's run loop (e.g. `btstack_run_loop` on the Pi Pico W).
- Dropped the `BluetoothHostControllerInterface` constraint from the class, since the all-async HCI protocol cannot be implemented by synchronous embedded stacks. The HCI-driven advertising APIs (async `start()` and `start(options:)`) moved to a constrained extension, so desktop and Linux behavior is unchanged. Re-advertising after a disconnect is a stored callback installed by `start(options:)`.
- Replaced `NSLock` with an internal `Lock` wrapper that is a no-op on platforms without threading, and the server callbacks capture the peripheral strongly on Embedded, where weak references are unavailable.
- The background thread driver is kept on platforms with Foundation threads, sharing the non-blocking accept implementation.

`GATTCentral` remains excluded from Embedded builds because `GATTClient` in `BluetoothGATT` is an actor and requires the concurrency runtime.

## CI

The WebAssembly and Embedded WebAssembly jobs now build both trait configurations.

## Testing

- macOS: full test suite passes in both trait configurations; symbol inspection confirms the peripheral, pure central, and `DarwinPeripheral` compile to nothing with the trait disabled while the shim types are used.
- WebAssembly and Embedded WebAssembly: build verified in both trait configurations, debug and release.