### PR TITLE
Add didConnect/didDisconnect callbacks to PeripheralManager

### DIFF
--- a/Sources/DarwinGATT/DarwinPeripheral.swift
+++ b/Sources/DarwinGATT/DarwinPeripheral.swift
@@ -39,9 +39,19 @@ public final class DarwinPeripheral: PeripheralManager, @unchecked Sendable {
     public var willWrite: ((GATTWriteRequest<Central, Data>) -> ATTError?)?
     
     public var didWrite: ((GATTWriteConfirmation<Central, Data>) -> ())?
-    
+
+    public var didConnect: ((Central) -> ())?
+
+    public var didDisconnect: ((Central) -> ())?
+
     public var stateChanged: ((DarwinBluetoothState) -> ())?
-    
+
+    public var connections: Set<Central> {
+        _connections
+    }
+
+    private var _connections = Set<Central>()
+
     private var database = Database()
     
     private var peripheralManager: CBPeripheralManager!
@@ -193,7 +203,20 @@ public final class DarwinPeripheral: PeripheralManager, @unchecked Sendable {
     }
     
     // MARK: - Private Methods
-    
+
+    /// Track a central as connected, notifying the delegate the first time it is observed.
+    fileprivate func addConnection(_ central: Central) {
+        guard _connections.contains(central) == false else { return }
+        _connections.insert(central)
+        didConnect?(central)
+    }
+
+    /// Track a central as disconnected, notifying the delegate.
+    fileprivate func removeConnection(_ central: Central) {
+        guard _connections.remove(central) != nil else { return }
+        didDisconnect?(central)
+    }
+
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     private func waitPeripheralReadyUpdateSubcribers() async {
         await withCheckedContinuation { [unowned self] continuation in
@@ -448,8 +471,9 @@ internal extension DarwinPeripheral {
         public func peripheralManager(_ peripheralManager: CBPeripheralManager, didReceiveRead request: CBATTRequest) {
             
             log("Did receive read request for \(request.characteristic.uuid)")
-            
+
             let peer = Central(request.central)
+            self.peripheral.addConnection(peer)
             let characteristic = self.peripheral.database[characteristic: request.characteristic]
             let uuid = BluetoothUUID(request.characteristic.uuid)
             let value = characteristic.value
@@ -489,6 +513,7 @@ internal extension DarwinPeripheral {
             
             let writeRequests: [GATTWriteRequest<Central, Data>] = requests.map { request in
                 let peer = Central(request.central)
+                self.peripheral.addConnection(peer)
                 let characteristic = self.peripheral.database[characteristic: request.characteristic]
                 let value = characteristic.value
                 let uuid = BluetoothUUID(request.characteristic.uuid)
@@ -543,11 +568,16 @@ internal extension DarwinPeripheral {
         @objc(peripheralManager:central:didSubscribeToCharacteristic:)
         public func peripheralManager(_ peripheral: CBPeripheralManager, central: CBCentral, didSubscribeTo characteristic: CBCharacteristic) {
             log("Central \(central.id) did subscribe to \(characteristic.uuid)")
+            // CoreBluetooth has no explicit "central connected" delegate method for the peripheral role,
+            // so the first subscription is used to infer that a central is connected.
+            self.peripheral.addConnection(Central(central))
         }
-        
+
         @objc
         public func peripheralManager(_ peripheral: CBPeripheralManager, central: CBCentral, didUnsubscribeFrom characteristic: CBCharacteristic) {
             log("Central \(central.id) did unsubscribe from \(characteristic.uuid)")
+            // Likewise, there is no explicit disconnect callback; unsubscribing is treated as disconnection.
+            self.peripheral.removeConnection(Central(central))
         }
         
         @objc

--- a/Sources/GATT/GATTPeripheral.swift
+++ b/Sources/GATT/GATTPeripheral.swift
@@ -75,7 +75,25 @@ public final class GATTPeripheral <HostController, Socket: L2CAPServer>: Periphe
             storage.didWrite = newValue
         }
     }
-    
+
+    public var didConnect: ((Central) -> ())? {
+        get {
+            storage.didConnect
+        }
+        set {
+            storage.didConnect = newValue
+        }
+    }
+
+    public var didDisconnect: ((Central) -> ())? {
+        get {
+            storage.didDisconnect
+        }
+        set {
+            storage.didDisconnect = newValue
+        }
+    }
+
     public var connections: Set<Central> {
         Set(storage.connections.values.lazy.map { $0.central })
     }
@@ -417,6 +435,8 @@ internal extension GATTPeripheral {
             }
         )
         storage.newConnection(connection)
+        // notify delegate
+        didConnect?(central)
         return connection
     }
 
@@ -470,6 +490,8 @@ internal extension GATTPeripheral {
         storage.removeConnection(central)
         // log
         log?("[\(central)]: " + "Did disconnect.")
+        // notify delegate
+        didDisconnect?(central)
     }
 }
 
@@ -535,7 +557,11 @@ internal extension GATTPeripheral {
         var willWrite: ((GATTWriteRequest<Central, Data>) -> ATTError?)?
         
         var didWrite: ((GATTWriteConfirmation<Central, Data>) -> ())?
-        
+
+        var didConnect: ((Central) -> ())?
+
+        var didDisconnect: ((Central) -> ())?
+
         var log: (@Sendable (String) -> ())?
         
         var socket: Socket?

--- a/Sources/GATT/PeripheralProtocol.swift
+++ b/Sources/GATT/PeripheralProtocol.swift
@@ -54,7 +54,13 @@ public protocol PeripheralManager {
     
     /// Callback to handle post-write actions for GATT write requests.
     var didWrite: ((GATTWriteConfirmation<Central, Data>) -> ())? { get set }
-    
+
+    /// Callback to handle when a central connects.
+    var didConnect: ((Central) -> ())? { get set }
+
+    /// Callback to handle when a central disconnects.
+    var didDisconnect: ((Central) -> ())? { get set }
+
     /// Modify the value of a characteristic, optionally emiting notifications if configured on active connections.
     func write(_ newValue: Data, forCharacteristic handle: UInt16)
     


### PR DESCRIPTION
## Problem

`PeripheralManager` exposes `willRead`/`willWrite`/`didWrite` callbacks but has no way to observe a central connecting or disconnecting. Consumers need this to, for example, stop advertising while connected, tear down per-connection state, or resume advertising after a disconnect.

`GATTPeripheral` already tracks connections internally (`connections: Set<Central>`, `didDisconnect(_:log:)`) but never surfaces connect/disconnect as a public event. `DarwinPeripheral` had no `connections` property at all, and its `CBPeripheralManagerDelegate` subscribe/unsubscribe callbacks only logged.

## Solution

- Add `var didConnect: ((Central) -> ())?` and `var didDisconnect: ((Central) -> ())?` to the `PeripheralManager` protocol, alongside the existing `willRead`/`willWrite`/`didWrite` callbacks.
- `GATTPeripheral`: add the two stored properties, invoke `didConnect` when a new connection is accepted, and invoke `didDisconnect` at the existing disconnect handling site.
- `DarwinPeripheral`: add the two stored properties plus a `connections: Set<Central>` property for parity with `GATTPeripheral`. Since CoreBluetooth's peripheral-manager role has no explicit "central connected" delegate method, connection is inferred from the first read/write request or characteristic subscription for a given central, and disconnection is inferred from `didUnsubscribeFrom`.

## Testing

- `swift build --traits BluetoothGATT`
- `swift build --traits BluetoothGATT --build-tests`
- `swift test --traits BluetoothGATT --filter GATTTests`