### PR TITLE
Expose out-of-band ATT MTU lookup on PeripheralManager

### DIFF
--- a/Sources/DarwinGATT/DarwinPeripheral.swift
+++ b/Sources/DarwinGATT/DarwinPeripheral.swift
@@ -169,7 +169,17 @@ public final class DarwinPeripheral: PeripheralManager, @unchecked Sendable {
     public func value(for characteristicHandle: UInt16, central: Central) -> Data {
         self[characteristic: characteristicHandle]
     }
-    
+
+    public func maximumTransmissionUnit(for central: Central) throws(Error) -> MaximumTransmissionUnit {
+        guard let cbCentral = central.central else {
+            throw DarwinPeripheralError.unknownCentral
+        }
+        guard let mtu = MaximumTransmissionUnit(rawValue: UInt16(cbCentral.maximumUpdateValueLength + 3)) else {
+            throw DarwinPeripheralError.unknownCentral
+        }
+        return mtu
+    }
+
     /// Read the value of the characteristic with specified handle.
     public subscript(characteristic handle: UInt16) -> Data {
         self.database[characteristic: handle]

--- a/Sources/DarwinGATT/DarwinPeripheralError.swift
+++ b/Sources/DarwinGATT/DarwinPeripheralError.swift
@@ -1,0 +1,45 @@
+//
+//  DarwinPeripheralError.swift
+//  GATT
+//
+//  Created by Alsey Coleman Miller on 7/20/26.
+//
+
+import Foundation
+
+#if canImport(CoreBluetooth)
+
+/// Errors for GATT Peripheral Manager
+public enum DarwinPeripheralError: Error {
+
+    /// The specified central is unknown or disconnected.
+    case unknownCentral
+}
+
+// MARK: - CustomNSError
+
+extension DarwinPeripheralError: CustomNSError {
+
+    public static var errorDomain: String {
+        return "org.pureswift.DarwinGATT.PeripheralError"
+    }
+
+    /// The user-info dictionary.
+    public var errorUserInfo: [String : Any] {
+
+        var userInfo = [String: Any](minimumCapacity: 1)
+
+        switch self {
+
+        case .unknownCentral:
+
+            let description = String(format: NSLocalizedString("Unknown or disconnected central.", comment: "org.pureswift.GATT.PeripheralError.unknownCentral"))
+
+            userInfo[NSLocalizedDescriptionKey] = description
+        }
+
+        return userInfo
+    }
+}
+
+#endif

--- a/Sources/GATT/GATTPeripheral.swift
+++ b/Sources/GATT/GATTPeripheral.swift
@@ -222,7 +222,14 @@ public final class GATTPeripheral <HostController, Socket: L2CAPServer>: Periphe
         }
         return connection[characteristicHandle]
     }
-    
+
+    public func maximumTransmissionUnit(for central: Central) throws(Error) -> MaximumTransmissionUnit {
+        guard let connection = storage.connections[central] else {
+            throw .disconnected(central)
+        }
+        return connection.maximumTransmissionUnit
+    }
+
     /// Return the handles of the characteristics matching the specified UUID.
     public func characteristics(for uuid: BluetoothUUID) -> [UInt16] {
         return storage.database

--- a/Sources/GATT/GATTServerConnection.swift
+++ b/Sources/GATT/GATTServerConnection.swift
@@ -28,6 +28,10 @@ internal final class GATTServerConnection <Socket: L2CAPConnection>: @unchecked 
         // ATT_MTU-3
         Int(server.maximumTransmissionUnit.rawValue) - 3
     }
+
+    public var maximumTransmissionUnit: ATTMaximumTransmissionUnit {
+        server.maximumTransmissionUnit
+    }
     
     private let lock = Lock()
     

--- a/Sources/GATT/PeripheralProtocol.swift
+++ b/Sources/GATT/PeripheralProtocol.swift
@@ -68,6 +68,11 @@ public protocol PeripheralManager {
     
     /// Read the value of the characteristic with specified handle for the specified connection.
     func value(for characteristicHandle: UInt16, central: Central) throws(Error) -> Data
+
+    /// The negotiated ATT MTU for the specified connected central.
+    ///
+    /// Throws error if central is unknown or disconnected.
+    func maximumTransmissionUnit(for central: Central) throws(Error) -> MaximumTransmissionUnit
 }
 
 // MARK: - Supporting Types


### PR DESCRIPTION
## Summary
- Add `maximumTransmissionUnit(for central:)` to the `PeripheralManager` protocol so implementations can look up the negotiated ATT MTU for a connected central outside of a read/write request callback (e.g. before proactively sending a notification/indication and needing to pre-fragment the payload).
- `GATTPeripheral`: implement the new requirement using the existing per-connection MTU tracking; expose the raw `ATTMaximumTransmissionUnit` from `GATTServerConnection` (previously only the derived `maximumUpdateValueLength` was public) and throw `.disconnected(central)` for an unknown/disconnected central, matching the convention used by `value(for:central:)`.
- `DarwinPeripheral`: implement the new requirement by reading `CBCentral.maximumUpdateValueLength` from the central already tracked on `DarwinPeripheral.Central`, converting back to the full ATT MTU (`maximumUpdateValueLength + 3`). Added `DarwinPeripheralError.unknownCentral` for the case where the central's `CBCentral` reference has been deallocated/disconnected, mirroring the existing `DarwinCentralError` pattern.

## Test plan
- [x] `swift build --traits BluetoothGATT`
- [x] `swift build` (default/shim trait configuration)
- [x] `swift test --traits BluetoothGATT --filter GATTTests` (all tests pass)