### PR TITLE
Return descriptor handles from PeripheralManager.add(service:)

### DIFF
--- a/Sources/DarwinGATT/DarwinPeripheral.swift
+++ b/Sources/DarwinGATT/DarwinPeripheral.swift
@@ -102,16 +102,16 @@ public final class DarwinPeripheral: PeripheralManager, @unchecked Sendable {
         peripheralManager.stopAdvertising()
     }
     
-    public func add(service: GATTAttribute<Data>.Service) -> (UInt16, [UInt16]) {
+    public func add(service: GATTAttribute<Data>.Service) -> GATTAddedService {
         // add service
         let serviceObject = service.toCoreBluetooth()
         peripheralManager.add(serviceObject)
         let handle = database.add(service: service, serviceObject)
         return handle
     }
-    
+
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-    public func add(service: GATTAttribute<Data>.Service) async throws -> (UInt16, [UInt16]) {
+    public func add(service: GATTAttribute<Data>.Service) async throws -> GATTAddedService {
         let serviceObject = service.toCoreBluetooth()
         // add service
         try await withCheckedThrowingContinuation { [unowned self] (continuation: CheckedContinuation<(), Error>) in
@@ -597,11 +597,11 @@ private extension DarwinPeripheral {
             return lastHandle
         }
         
-        mutating func add(service: GATTAttribute<Data>.Service, _ coreService: CBMutableService) -> (UInt16, [UInt16]) {
-            
+        mutating func add(service: GATTAttribute<Data>.Service, _ coreService: CBMutableService) -> GATTAddedService {
+
             let serviceHandle = newHandle()
-            var characteristicHandles = [UInt16]()
-            characteristicHandles.reserveCapacity((coreService.characteristics ?? []).count)
+            var addedCharacteristics = [GATTAddedService.AddedCharacteristic]()
+            addedCharacteristics.reserveCapacity((coreService.characteristics ?? []).count)
             services[coreService] = Service(handle: serviceHandle)
             for (index, characteristic) in ((coreService.characteristics ?? []) as! [CBMutableCharacteristic]).enumerated()  {
                 let data = service.characteristics[index].value
@@ -611,9 +611,13 @@ private extension DarwinPeripheral {
                     serviceHandle: serviceHandle,
                     value: data
                 )
-                characteristicHandles.append(characteristicHandle)
+                // Only descriptors CoreBluetooth actually accepted (see `toCoreBluetooth()`) are assigned handles here.
+                let descriptorHandles = (characteristic.descriptors as? [CBMutableDescriptor] ?? []).map { _ in newHandle() }
+                addedCharacteristics.append(
+                    GATTAddedService.AddedCharacteristic(handle: characteristicHandle, descriptors: descriptorHandles)
+                )
             }
-            return (serviceHandle, characteristicHandles)
+            return GATTAddedService(handle: serviceHandle, characteristics: addedCharacteristics)
         }
         
         mutating func remove(service handle: UInt16) {

--- a/Sources/GATT/GATTPeripheral.swift
+++ b/Sources/GATT/GATTPeripheral.swift
@@ -187,7 +187,7 @@ public final class GATTPeripheral <HostController, Socket: L2CAPServer>: Periphe
         log?("Stopped GATT Server")
     }
     
-    public func add(service: BluetoothGATT.GATTAttribute<Data>.Service) -> (UInt16, [UInt16]) {
+    public func add(service: BluetoothGATT.GATTAttribute<Data>.Service) -> GATTAddedService {
         return storage.add(service: service)
     }
     
@@ -564,7 +564,7 @@ internal extension GATTPeripheral {
             #endif
         }
         
-        mutating func add(service: GATTAttribute<Data>.Service) -> (UInt16, [UInt16]) {
+        mutating func add(service: GATTAttribute<Data>.Service) -> GATTAddedService {
             var includedServicesHandles = [UInt16]()
             var characteristicDeclarationHandles = [UInt16]()
             var characteristicValueHandles = [UInt16]()
@@ -576,7 +576,10 @@ internal extension GATTPeripheral {
                 characteristicValueHandles: &characteristicValueHandles,
                 descriptorHandles: &descriptorHandles
             )
-            return (serviceHandle, characteristicValueHandles)
+            let characteristics = zip(characteristicValueHandles, descriptorHandles).map { characteristicValueHandle, descriptorHandles in
+                GATTAddedService.AddedCharacteristic(handle: characteristicValueHandle, descriptors: descriptorHandles)
+            }
+            return GATTAddedService(handle: serviceHandle, characteristics: characteristics)
         }
         
         mutating func remove(service handle: UInt16) {

--- a/Sources/GATT/PeripheralProtocol.swift
+++ b/Sources/GATT/PeripheralProtocol.swift
@@ -37,8 +37,9 @@ public protocol PeripheralManager {
     
     /// Attempts to add the specified service to the GATT database.
     ///
-    /// - Returns: Handle for service declaration and handles for characteristic value handles.
-    func add(service: BluetoothGATT.GATTAttribute<Data>.Service) throws(Error) -> (UInt16, [UInt16])
+    /// - Returns: The handle assigned to the service declaration, along with the handles assigned
+    ///   to each of its characteristics (and their descriptors), mirroring the structure of `service`.
+    func add(service: BluetoothGATT.GATTAttribute<Data>.Service) throws(Error) -> GATTAddedService
     
     /// Removes the service with the specified handle.
     func remove(service: UInt16)
@@ -71,6 +72,39 @@ public protocol PeripheralManager {
 }
 
 // MARK: - Supporting Types
+
+/// The handles assigned when adding a service to a peripheral's GATT database.
+public struct GATTAddedService: Equatable, Hashable, Sendable {
+
+    /// The handle assigned to the service declaration.
+    public let handle: UInt16
+
+    /// The characteristics added for this service, in the same order as the input service.
+    public let characteristics: [AddedCharacteristic]
+
+    public init(handle: UInt16, characteristics: [AddedCharacteristic]) {
+        self.handle = handle
+        self.characteristics = characteristics
+    }
+}
+
+public extension GATTAddedService {
+
+    /// The handles assigned when adding a characteristic to a peripheral's GATT database.
+    struct AddedCharacteristic: Equatable, Hashable, Sendable {
+
+        /// The handle assigned to the characteristic value.
+        public let handle: UInt16
+
+        /// The handles assigned to the characteristic's descriptors, in the same order as the input descriptors.
+        public let descriptors: [UInt16]
+
+        public init(handle: UInt16, descriptors: [UInt16]) {
+            self.handle = handle
+            self.descriptors = descriptors
+        }
+    }
+}
 
 public protocol GATTRequest {
     

--- a/Tests/GATTTests/GATTTests.swift
+++ b/Tests/GATTTests/GATTTests.swift
@@ -258,10 +258,10 @@ final class GATTTests: XCTestCase {
         
         try await connect(
             server: { peripheral in
-                let (serviceAttributeHandle, characteristicValueHandles) = peripheral.add(service: service)
-                serviceAttribute = serviceAttributeHandle
+                let addedService = peripheral.add(service: service)
+                serviceAttribute = addedService.handle
                 XCTAssertEqual(serviceAttribute, 1)
-                characteristicValueHandle = characteristicValueHandles[0]
+                characteristicValueHandle = addedService.characteristics[0].handle
                 peripheralDatabaseValue = { peripheral[characteristic: characteristicValueHandle] }
                 let currentValue = await peripheralDatabaseValue()
                 XCTAssertEqual(currentValue, characteristics[0].value)
@@ -334,9 +334,9 @@ final class GATTTests: XCTestCase {
             serverOptions: .init(maximumTransmissionUnit: .default, maximumPreparedWrites: 1000),
             clientOptions: .init(maximumTransmissionUnit: .max),
             server: { peripheral in
-                let (serviceAttribute, characteristicValueHandles) = peripheral.add(service: service)
-                XCTAssertEqual(serviceAttribute, 1)
-                let characteristicValueHandle = characteristicValueHandles[0]
+                let addedService = peripheral.add(service: service)
+                XCTAssertEqual(addedService.handle, 1)
+                let characteristicValueHandle = addedService.characteristics[0].handle
                 Task {
                     try await Task.sleep(nanoseconds: 1_000_000_000)
                     peripheral.write(Data(newValue), forCharacteristic: characteristicValueHandle)
@@ -399,9 +399,9 @@ final class GATTTests: XCTestCase {
             serverOptions: .init(maximumTransmissionUnit: .default, maximumPreparedWrites: 1000),
             clientOptions: .init(maximumTransmissionUnit: .max),
             server: { peripheral in
-                let (serviceAttribute, characteristicValueHandles) = peripheral.add(service: service)
-                XCTAssertEqual(serviceAttribute, 1)
-                let characteristicValueHandle = characteristicValueHandles[0]
+                let addedService = peripheral.add(service: service)
+                XCTAssertEqual(addedService.handle, 1)
+                let characteristicValueHandle = addedService.characteristics[0].handle
                 Task {
                     try await Task.sleep(nanoseconds: 1_000_000_000)
                     peripheral.write(Data(newValue), forCharacteristic: characteristicValueHandle)
@@ -469,8 +469,10 @@ final class GATTTests: XCTestCase {
             serverOptions: .init(maximumTransmissionUnit: .default, maximumPreparedWrites: 1000),
             clientOptions: .init(maximumTransmissionUnit: .default),
             server: { peripheral in
-                let (serviceAttribute, _) = peripheral.add(service: service)
-                XCTAssertEqual(serviceAttribute, 1)
+                let addedService = peripheral.add(service: service)
+                XCTAssertEqual(addedService.handle, 1)
+                XCTAssertEqual(addedService.characteristics.count, 1)
+                XCTAssertEqual(addedService.characteristics[0].descriptors.count, descriptors.count)
             },
             client: { (central, peripheral) in
                 let services = try await central.discoverServices(for: peripheral)


### PR DESCRIPTION
## Summary

`PeripheralManager.add(service:)` previously returned a flat `(UInt16, [UInt16])` tuple — the service handle and the characteristic value handles — with no way to get at the handles assigned to descriptors. Callers that needed descriptor handles had to manually re-walk the input `GATTAttribute.Service` tree by index to correlate it with the returned handles.

This replaces the tuple with a new `GATTAddedService` type that mirrors the shape of the input service:

```swift
public struct GATTAddedService: Equatable, Hashable, Sendable {
    public let handle: UInt16
    public let characteristics: [AddedCharacteristic]

    public struct AddedCharacteristic: Equatable, Hashable, Sendable {
        public let handle: UInt16
        public let descriptors: [UInt16]
    }
}
```

**This is a breaking API change** to the `PeripheralManager` protocol's `add(service:)` requirement.

### Changes
- `Sources/GATT/PeripheralProtocol.swift`: add `GATTAddedService`/`AddedCharacteristic`, change the protocol requirement's return type.
- `Sources/GATT/GATTPeripheral.swift`: `Storage.add(service:)` already computed `descriptorHandles` internally via `GATTDatabase.add(...)` but discarded it; now it's used to populate `GATTAddedService`.
- `Sources/DarwinGATT/DarwinPeripheral.swift`: `DarwinPeripheral.Database.add(service:_:)` now also assigns simulated handles to each characteristic's descriptors (only the `CBMutableDescriptor`s CoreBluetooth actually accepted, since `toCoreBluetooth()` filters out descriptor UUIDs CoreBluetooth doesn't support), for both the sync and async `add(service:)` overloads.
- `Tests/GATTTests/GATTTests.swift`: updated call sites to use the new structured result instead of tuple destructuring.

## Test plan
- [x] `swift build --traits BluetoothGATT`
- [x] `swift test --traits BluetoothGATT` (all tests pass, including `testDescriptors`)