### PR TITLE
Let willRead override the response value

### DIFF
--- a/Sources/DarwinGATT/DarwinPeripheral.swift
+++ b/Sources/DarwinGATT/DarwinPeripheral.swift
@@ -34,7 +34,7 @@ public final class DarwinPeripheral: PeripheralManager, @unchecked Sendable {
         self.peripheralManager.isAdvertising
     }
     
-    public var willRead: ((GATTReadRequest<Central, Data>) -> ATTError?)?
+    public var willRead: ((GATTReadRequest<Central, Data>) -> Result<Data, ATTError>)?
     
     public var willWrite: ((GATTWriteRequest<Central, Data>) -> ATTError?)?
     
@@ -466,12 +466,18 @@ internal extension DarwinPeripheral {
                 peripheralManager.respond(to: request, withResult: .invalidOffset)
                 return
             }
-            if let error = self.peripheral.willRead?(readRequest) {
-                peripheralManager.respond(to: request, withResult: CBATTError.Code(rawValue: Int(error.rawValue))!)
-                return
+            var responseValue = value
+            if let result = self.peripheral.willRead?(readRequest) {
+                switch result {
+                case let .success(newValue):
+                    responseValue = newValue
+                case let .failure(error):
+                    peripheralManager.respond(to: request, withResult: CBATTError.Code(rawValue: Int(error.rawValue))!)
+                    return
+                }
             }
-            
-            let requestedValue = request.offset == 0 ? value : Data(value.suffix(request.offset))
+
+            let requestedValue = request.offset == 0 ? responseValue : Data(responseValue.suffix(request.offset))
             request.value = requestedValue
             peripheralManager.respond(to: request, withResult: .success)
         }

--- a/Sources/GATT/GATTPeripheral.swift
+++ b/Sources/GATT/GATTPeripheral.swift
@@ -49,7 +49,7 @@ public final class GATTPeripheral <HostController, Socket: L2CAPServer>: Periphe
         }
     }
     
-    public var willRead: ((GATTReadRequest<Central, Data>) -> ATTError?)? {
+    public var willRead: ((GATTReadRequest<Central, Data>) -> Result<Data, ATTError>)? {
         get {
             storage.willRead
         }
@@ -365,7 +365,17 @@ internal extension GATTPeripheral {
             value: value,
             offset: offset
         )
-        return willRead?(request)
+        guard let result = willRead?(request) else {
+            return nil
+        }
+        switch result {
+        case let .success(newValue):
+            // override the stored value so it is served as the response
+            write(newValue, forCharacteristic: handle)
+            return nil
+        case let .failure(error):
+            return error
+        }
     }
     
     func willWrite(central: Central, uuid: BluetoothUUID, handle: UInt16, value: Data, newValue: Data) -> ATTError? {
@@ -530,7 +540,7 @@ internal extension GATTPeripheral {
         
         var database = GATTDatabase<Data>()
         
-        var willRead: ((GATTReadRequest<Central, Data>) -> ATTError?)?
+        var willRead: ((GATTReadRequest<Central, Data>) -> Result<Data, ATTError>)?
         
         var willWrite: ((GATTWriteRequest<Central, Data>) -> ATTError?)?
         

--- a/Sources/GATT/PeripheralProtocol.swift
+++ b/Sources/GATT/PeripheralProtocol.swift
@@ -47,7 +47,10 @@ public protocol PeripheralManager {
     func removeAllServices()
     
     /// Callback to handle GATT read requests.
-    var willRead: ((GATTReadRequest<Central, Data>) -> ATTError?)? { get set }
+    ///
+    /// Return `.success` with the data to serve as the response, overriding the value
+    /// stored in the GATT database, or `.failure` to reject the request with the given error.
+    var willRead: ((GATTReadRequest<Central, Data>) -> Result<Data, ATTError>)? { get set }
     
     /// Callback to handle GATT write requests.
     var willWrite: ((GATTWriteRequest<Central, Data>) -> ATTError?)? { get set }


### PR DESCRIPTION
## Summary

**Breaking API change.** `PeripheralManager.willRead` now returns `Result<Data, ATTError>` instead of `ATTError?`:

```swift
var willRead: ((GATTReadRequest<Central, Data>) -> Result<Data, ATTError>)? { get set }
```

Previously the closure could only signal an error (`ATTError?`), never supply the response body. That forced write-then-read protocols (client writes a request PDU, then reads the response) to stage the response by writing it to the GATT database from `didWrite`, then serve it from stored state on the next read — an awkward extra round trip. With `willRead` able to return `.success(data)`, callers can compute the response lazily at read time instead.

- `.success(let data)` — serve `data` as the response instead of the value already stored in the database.
- `.failure(let error)` — reject the request with that ATT error, same as the previous `ATTError?`-returning behavior.
- `willRead` itself stays optional (`nil` = no hook installed, proceed with the stored value); once installed the closure must always return a definite `Result`.

## Changes

- `Sources/GATT/PeripheralProtocol.swift`: updated the protocol requirement's signature.
- `Sources/GATT/GATTPeripheral.swift`: on `.success`, writes the returned data into the GATT database so it's served as the response; on `.failure`, rejects the read with that error.
- `Sources/DarwinGATT/DarwinPeripheral.swift`: on `.success`, uses the returned data as the `CBATTRequest` response value; on `.failure`, responds with the corresponding `CBATTError.Code`.

## Test plan

- [x] `swift build --traits BluetoothGATT` succeeds
- [x] `swift test --traits BluetoothGATT` — all 14 tests pass