### PR TITLE
Add indication-confirmation callback to PeripheralManager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ var package = Package(
     dependencies: [
         .package(
             url: "https://github.com/PureSwift/Bluetooth.git",
-            from: "7.5.0"
+            from: "8.0.0"
         )
     ],
     targets: [

--- a/Sources/DarwinGATT/DarwinPeripheral.swift
+++ b/Sources/DarwinGATT/DarwinPeripheral.swift
@@ -44,6 +44,27 @@ public final class DarwinPeripheral: PeripheralManager, @unchecked Sendable {
 
     public var didDisconnect: ((Central) -> ())?
 
+    /// Callback invoked when a central acknowledges (confirms) an indication for the
+    /// specified characteristic handle.
+    ///
+    /// - Note: CoreBluetooth does not report ATT-level indication confirmations
+    ///   directly; `CBPeripheralManagerDelegate` has no `didConfirm`-style method.
+    ///   The only related signal is `peripheralManagerIsReady(toUpdateSubscribers:)`,
+    ///   which fires when the shared transmit queue (used for both notifications and
+    ///   indications, across all subscribed centrals) has space again after a prior
+    ///   `updateValue(_:for:onSubscribedCentrals:)` call returned `false`. Because
+    ///   CoreBluetooth will not accept another update for a central while an
+    ///   indication to that central is unconfirmed, this callback is invoked as a
+    ///   best-effort proxy: only for calls to `write(_:forCharacteristic:for:)` (a
+    ///   single, explicit central) that initially failed to enqueue and only
+    ///   succeeded after waiting for `peripheralManagerIsReady`. This is a heuristic,
+    ///   not a verified per-characteristic confirmation — the queue can also free up
+    ///   for reasons unrelated to that specific central or characteristic (e.g. a
+    ///   plain notification draining, or another central's indication being
+    ///   confirmed), and it is never invoked for the broadcast `write(_:forCharacteristic:)`
+    ///   since no single central can be attributed there.
+    public var didConfirm: ((Central, UInt16) -> ())?
+
     public var stateChanged: ((DarwinBluetoothState) -> ())?
 
     public var connections: Set<Central> {
@@ -173,7 +194,27 @@ public final class DarwinPeripheral: PeripheralManager, @unchecked Sendable {
     }
     
     public func write(_ newValue: Data, forCharacteristic handle: UInt16, for central: Central) {
-        write(newValue, forCharacteristic: handle) // per-connection database not supported on Darwin
+        // update GATT DB (shared; per-connection database not supported on Darwin)
+        database[characteristic: handle] = newValue
+        // send notification/indication to only the specified central
+        if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
+            Task {
+                var didNotify = updateValue(newValue, forCharacteristic: handle, centrals: [central])
+                var didWaitForTransmitQueue = false
+                while didNotify == false {
+                    didWaitForTransmitQueue = true
+                    await waitPeripheralReadyUpdateSubcribers()
+                    didNotify = updateValue(newValue, forCharacteristic: handle, centrals: [central])
+                }
+                // Best-effort indication confirmation heuristic.
+                // See the `didConfirm` documentation for its limitations.
+                if didWaitForTransmitQueue {
+                    didConfirm?(central, handle)
+                }
+            }
+        } else {
+            updateValue(newValue, forCharacteristic: handle, centrals: [central])
+        }
     }
     
     public func value(for characteristicHandle: UInt16, central: Central) -> Data {

--- a/Sources/GATT/GATTPeripheral.swift
+++ b/Sources/GATT/GATTPeripheral.swift
@@ -96,15 +96,6 @@ public final class GATTPeripheral <HostController, Socket: L2CAPServer>: Periphe
 
     /// Callback invoked when a central acknowledges (confirms) an indication for the
     /// specified characteristic handle.
-    ///
-    /// - Warning: Never invoked. `Bluetooth.GATTServer`, the ATT server implementation
-    ///   backing this type, already receives ATT indication confirmations
-    ///   (`ATTHandleValueConfirmation`) from `send(_:response:)`, but only logs them —
-    ///   it does not forward them through its public `Callback` struct, which exposes
-    ///   only `willRead`, `willWrite`, and `didWrite`. Surfacing confirmations here
-    ///   requires adding a corresponding hook (e.g. `didConfirm`) to `GATTServer.Callback`
-    ///   upstream in the `PureSwift/Bluetooth` package; until then this property is kept
-    ///   only to satisfy `PeripheralManager` conformance.
     public var didConfirm: ((Central, UInt16) -> ())? {
         get {
             storage.didConfirm
@@ -378,6 +369,9 @@ internal extension GATTPeripheral {
         callback.didWrite = { (uuid, handle, value) in
             self.didWrite(central: central, uuid: uuid, handle: handle, value: value)
         }
+        callback.didConfirm = { (uuid, handle) in
+            self.didConfirm(central: central, uuid: uuid, handle: handle)
+        }
         #else
         callback.willRead = { [weak self] in
             self?.willRead(central: central, uuid: $0, handle: $1, value: $2, offset: $3)
@@ -387,6 +381,9 @@ internal extension GATTPeripheral {
         }
         callback.didWrite = { [weak self] (uuid, handle, value) in
             self?.didWrite(central: central, uuid: uuid, handle: handle, value: value)
+        }
+        callback.didConfirm = { [weak self] (uuid, handle) in
+            self?.didConfirm(central: central, uuid: uuid, handle: handle)
         }
         #endif
         return callback
@@ -449,6 +446,10 @@ internal extension GATTPeripheral {
         write(confirmation.value, forCharacteristic: confirmation.handle, ignore: confirmation.central)
         // notify delegate
         didWrite?(confirmation)
+    }
+
+    func didConfirm(central: Central, uuid: BluetoothUUID, handle: UInt16) {
+        didConfirm?(central, handle)
     }
     
     /// Accept a pending connection, without blocking.

--- a/Sources/GATT/GATTPeripheral.swift
+++ b/Sources/GATT/GATTPeripheral.swift
@@ -94,6 +94,26 @@ public final class GATTPeripheral <HostController, Socket: L2CAPServer>: Periphe
         }
     }
 
+    /// Callback invoked when a central acknowledges (confirms) an indication for the
+    /// specified characteristic handle.
+    ///
+    /// - Warning: Never invoked. `Bluetooth.GATTServer`, the ATT server implementation
+    ///   backing this type, already receives ATT indication confirmations
+    ///   (`ATTHandleValueConfirmation`) from `send(_:response:)`, but only logs them —
+    ///   it does not forward them through its public `Callback` struct, which exposes
+    ///   only `willRead`, `willWrite`, and `didWrite`. Surfacing confirmations here
+    ///   requires adding a corresponding hook (e.g. `didConfirm`) to `GATTServer.Callback`
+    ///   upstream in the `PureSwift/Bluetooth` package; until then this property is kept
+    ///   only to satisfy `PeripheralManager` conformance.
+    public var didConfirm: ((Central, UInt16) -> ())? {
+        get {
+            storage.didConfirm
+        }
+        set {
+            storage.didConfirm = newValue
+        }
+    }
+
     public var connections: Set<Central> {
         Set(storage.connections.values.lazy.map { $0.central })
     }
@@ -578,6 +598,8 @@ internal extension GATTPeripheral {
         var didConnect: ((Central) -> ())?
 
         var didDisconnect: ((Central) -> ())?
+
+        var didConfirm: ((Central, UInt16) -> ())?
 
         var log: (@Sendable (String) -> ())?
         

--- a/Sources/GATT/PeripheralProtocol.swift
+++ b/Sources/GATT/PeripheralProtocol.swift
@@ -59,11 +59,21 @@ public protocol PeripheralManager {
     /// Callback to handle post-write actions for GATT write requests.
     var didWrite: ((GATTWriteConfirmation<Central, Data>) -> ())? { get set }
 
-    /// Callback to handle when a central connects.
+/// Callback to handle when a central connects.
     var didConnect: ((Central) -> ())? { get set }
 
     /// Callback to handle when a central disconnects.
     var didDisconnect: ((Central) -> ())? { get set }
+
+    /// Callback invoked when a central acknowledges (confirms) an indication for the
+    /// specified characteristic handle.
+    ///
+    /// Indications differ from notifications in that the central sends an ATT
+    /// confirmation once it receives the value, letting the peripheral know delivery
+    /// succeeded. Not every backend is able to observe that confirmation with
+    /// central / characteristic granularity; see the documentation on each
+    /// conforming type for what, if anything, triggers this callback.
+    var didConfirm: ((Central, UInt16) -> ())? { get set }
 
     /// Modify the value of a characteristic, optionally emiting notifications if configured on active connections.
     func write(_ newValue: Data, forCharacteristic handle: UInt16)


### PR DESCRIPTION
## Problem

`write(_:forCharacteristic:)` / `write(_:forCharacteristic:for:)` on `PeripheralManager` only document that they "optionally emit notifications if configured" — there is no way for a caller to learn that a central actually confirmed an indication. Protocols that need HAP-BLE-style confirmed delivery (indications, not notifications) currently have no signal for this.

## What this adds

A new protocol requirement in `Sources/GATT/PeripheralProtocol.swift`:

```swift
var didConfirm: ((Central, UInt16) -> ())? { get set }
```

alongside the existing `willRead` / `willWrite` / `didWrite` callbacks.

## Upstream dependency

`PureSwift/Bluetooth` is now required at `8.0.0`, which adds a `didConfirm` hook to `GATTServer.Callback` (`Sources/BluetoothGATT/GATTServer.swift`) and forwards the ATT indication confirmation it already receives in `didWriteAttribute`'s `send(indication) { ... }` completion handler, previously only logged and discarded.

With that in place:

- `GATTPeripheral` (the generic, `GATTServer`-backed implementation used on Linux/embedded/etc.) now wires `GATTServer.Callback.didConfirm` straight through to its own `didConfirm` property — real, per-central, per-characteristic confirmation delivery, not a heuristic.
- `DarwinPeripheral` (CoreBluetooth-backed) does not go through `GATTServer`, so it isn't affected by that change either way. CoreBluetooth itself has no confirmation-delivery delegate method — the only related signal is `peripheralManagerIsReady(toUpdateSubscribers:)`, which fires when the shared transmit queue (used for all subscribers and both notifications and indications) has space again after `updateValue(_:for:onSubscribedCentrals:)` returned `false`. Since CoreBluetooth withholds further updates to a central while an indication to it is outstanding, `write(_:forCharacteristic:for:)` uses that as a best-effort heuristic: it targets the single specified central (previously it silently broadcast to all subscribers, ignoring the `central` parameter) and invokes `didConfirm` when that update had to wait on the queue before it could be sent. This remains a heuristic, not a verified per-characteristic confirmation, since the queue can also free up for unrelated reasons — documented as such on the property.

## Changes

- `Sources/GATT/PeripheralProtocol.swift`: add `didConfirm` protocol requirement.
- `Sources/GATT/GATTPeripheral.swift`: add `didConfirm` storage/property, wired to the underlying `GATTServer.Callback.didConfirm`.
- `Sources/DarwinGATT/DarwinPeripheral.swift`: implement best-effort `didConfirm` via `peripheralManagerIsReady(toUpdateSubscribers:)`; fix `write(_:forCharacteristic:for:)` to actually target the specified central.
- `Package.swift`: bump `Bluetooth` dependency to `8.0.0`.

## Test plan

- [x] `swift build --traits BluetoothGATT` succeeds
- [x] `swift test --traits BluetoothGATT` passes (14/14)
- [ ] Exercise indication delivery against a real central to validate the Darwin heuristic in practice (not covered by this PR)