### PR TITLE
Import the embedded Foundation shim in AdvertisementData

### DIFF
--- a/Sources/GATT/AdvertisementData.swift
+++ b/Sources/GATT/AdvertisementData.swift
@@ -6,6 +6,15 @@
 //  Copyright © 2018 PureSwift. All rights reserved.
 //
 
+#if canImport(Foundation)
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+#elseif canImport(FoundationEmbedded)
+import FoundationEmbedded
+#endif
 @_exported import Bluetooth
 #if canImport(BluetoothGAP)
 import BluetoothGAP


### PR DESCRIPTION
## Problem

`AdvertisementData.swift` decodes the 128-bit service class UUID lists into `UUID`, but only imports `Bluetooth` and `BluetoothGAP`. Under Embedded Swift that leaves the type with no declaring module in scope:

```
error: struct 'UUID' cannot be used in an embedded function not marked
'@export(interface)' because 'FoundationEmbedded' was not imported by this file
```

## Why CI doesn't catch it

The embedded job builds `--target GATT` on its own. `BluetoothGAP` isn't in the graph, so the whole `#if canImport(BluetoothGAP)` block compiles out and the offending lines are never type-checked.

It only surfaces once something else in the dependency graph pulls `BluetoothGAP` in — a package building a GATT server, for instance. In that configuration the block is live and the module fails to build (13 errors, all in this file).

Might be worth adding a matrix case that builds a small consumer rather than the target alone, otherwise this class of bug stays invisible.

## Fix

Adds the same conditional Foundation import that `BluetoothGAP` itself uses for the type it hands back — see `Sources/BluetoothGAP/GAPCompleteListOf128BitServiceClassUUIDs.swift`.

## Verification

- Embedded, in a dependency graph that includes `BluetoothGAP`: 13 errors → 0
- `swift build --target GATT --swift-sdk swift-6.3.3-RELEASE_wasm-embedded`: clean
- `swift build --traits BluetoothGATT`: clean
- `swift test`: 7/7 passing

The last two matter because adding a Foundation import is exactly the kind of change that can regress a non-embedded build.
